### PR TITLE
Refactor: Replace utils.MODEL_DIR with settings.MODEL_DIR

### DIFF
--- a/mainapp/api.py
+++ b/mainapp/api.py
@@ -3,13 +3,12 @@ import json
 from collections import defaultdict
 from zipfile import ZipFile
 
-from django.shortcuts import render, get_object_or_404, redirect
-from django.contrib.auth.models import User
-from django.http import JsonResponse, FileResponse, Http404, HttpResponseBadRequest, HttpResponse
+from django.conf import settings
+from django.shortcuts import get_object_or_404
+from django.http import JsonResponse, FileResponse, Http404, HttpResponseBadRequest
 from django.core.paginator import Paginator, EmptyPage
 from .models import LatestModel, Comment, Model
-from .utils import get_kv, MODEL_DIR, admin
-from django.db.models import Max
+from .utils import get_kv, admin
 from django.views.decorators.csrf import csrf_exempt
 
 RESULTS_PER_API_CALL= 20
@@ -87,7 +86,7 @@ def get_model(request, model_id, revision=None):
         raise Http404('Model does not exist.')
 
 
-    response = FileResponse(open('{}/{}/{}.zip'.format(MODEL_DIR, model_id, revision), 'rb'))
+    response = FileResponse(open('{}/{}/{}.zip'.format(settings.MODEL_DIR, model_id, revision), 'rb'))
     response['Content-Disposition'] = 'attachment; filename={}.zip'.format(revision)
     response['Content-Type'] = 'application/zip'
     response['Cache-Control'] = 'public, max-age=86400'

--- a/mainapp/database.py
+++ b/mainapp/database.py
@@ -3,10 +3,10 @@ import logging
 import mistune
 
 from django.db import transaction
+from django.conf import settings
 from django.contrib import messages
 
 from .models import Model, LatestModel, Change, Category, Location
-from .utils import MODEL_DIR
 
 from mainapp.markdown import markdown
 
@@ -94,7 +94,7 @@ def upload(model_file, options={}):
 
             change.save()
 
-            filepath = '{}/{}/{}.zip'.format(MODEL_DIR, m.model_id, m.revision)
+            filepath = '{}/{}/{}.zip'.format(settings.MODEL_DIR, m.model_id, m.revision)
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, 'wb+') as destination:
                 for chunk in model_file.chunks():

--- a/mainapp/management/commands/nightly.py
+++ b/mainapp/management/commands/nightly.py
@@ -1,8 +1,8 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.dateformat import format
 from mainapp.models import LatestModel
 from json import dumps
-from mainapp.utils import MODEL_DIR
 from zipfile import ZipFile
 
 class Command(BaseCommand):
@@ -55,7 +55,7 @@ class Command(BaseCommand):
             })
 
             info_file.write('"{}": {}\n'.format(model_id, output))
-            zip_file.write('{}/{}/{}.zip'.format(MODEL_DIR, model_id, model.revision), 'models/{}.zip'.format(model_id))
+            zip_file.write('{}/{}/{}.zip'.format(settings.MODEL_DIR, model_id, model.revision), 'models/{}.zip'.format(model_id))
 
         info_file.write('}')
         info_file.close()

--- a/mainapp/tests/mixins.py
+++ b/mainapp/tests/mixins.py
@@ -1,14 +1,19 @@
 import os
 import shutil
+import tempfile
 
 from django.conf import settings
+from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
 from social_django.models import UserSocialAuth
 
 from mainapp.models import Category, LatestModel, Location, Model
 
 
-class BaseViewTestMixin:
+@override_settings(
+    MODEL_DIR=tempfile.mkdtemp(prefix="3dmr_")
+)
+class BaseViewTestMixin(TestCase):
     """
     A mixin to set up a base test environment with a user,
     admin user, and models. This mixin creates a user and an admin user, along with some models and categories.
@@ -101,9 +106,7 @@ class BaseViewTestMixin:
                 destination.write(self.model_file)
 
     def tearDown(self) -> None:
-        for dir_path in set(self.model_dirs):
-            if os.path.exists(dir_path):
-                shutil.rmtree(dir_path)
+        shutil.rmtree(settings.MODEL_DIR)
 
     def login_user(self, user_type="user"):
         """

--- a/mainapp/tests/mixins.py
+++ b/mainapp/tests/mixins.py
@@ -1,11 +1,11 @@
 import os
 import shutil
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from social_django.models import UserSocialAuth
 
 from mainapp.models import Category, LatestModel, Location, Model
-from mainapp.utils import MODEL_DIR
 
 
 class BaseViewTestMixin:
@@ -94,7 +94,7 @@ class BaseViewTestMixin:
         self.model_dirs = []
 
         for model in [self.model1, self.model2, self.model3]:
-            filepath = f"{MODEL_DIR}/{model.model_id}/{model.revision}.zip"
+            filepath = f"{settings.MODEL_DIR}/{model.model_id}/{model.revision}.zip"
             self.model_dirs.append(os.path.dirname(filepath))
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, "wb+") as destination:

--- a/mainapp/tests/test_database.py
+++ b/mainapp/tests/test_database.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 from mainapp import database
 from mainapp.markdown import markdown
 from mainapp.models import Category, Change, LatestModel, Location, Model
-from mainapp.utils import MODEL_DIR
+from django.conf import settings
 
 User = get_user_model()
 
@@ -25,7 +25,7 @@ class DatabaseTests(TestCase):
 
     def tearDown(self):
         for model in LatestModel.objects.all():
-            filepath = f"{MODEL_DIR}/{model.model_id}/{model.revision}.zip"
+            filepath = f"{settings.MODEL_DIR}/{model.model_id}/{model.revision}.zip"
             if os.path.exists(filepath):
                 shutil.rmtree(os.path.dirname(filepath))
 
@@ -85,7 +85,7 @@ class DatabaseTests(TestCase):
         self.assertEqual(created_model.location.longitude, options["longitude"])
 
         expected_filepath = os.path.join(
-            MODEL_DIR, str(created_model.model_id), f"{created_model.revision}.zip"
+            settings.MODEL_DIR, str(created_model.model_id), f"{created_model.revision}.zip"
         )
         self.assertTrue(os.path.exists(expected_filepath))
 
@@ -230,7 +230,7 @@ class DatabaseTests(TestCase):
         self.assertEqual(Location.objects.count(), 2)
 
         expected_filepath_rev = os.path.join(
-            MODEL_DIR, str(revised_model.model_id), f"{revised_model.revision}.zip"
+            settings.MODEL_DIR, str(revised_model.model_id), f"{revised_model.revision}.zip"
         )
         self.assertTrue(os.path.exists(expected_filepath_rev))
 

--- a/mainapp/tests/test_database.py
+++ b/mainapp/tests/test_database.py
@@ -1,7 +1,9 @@
 import os
 import shutil
+import tempfile
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
@@ -14,6 +16,9 @@ from django.conf import settings
 User = get_user_model()
 
 
+@override_settings(
+    MODEL_DIR=tempfile.mkdtemp(prefix="3dmr_", )
+)
 class DatabaseTests(TestCase):
 
     def setUp(self):
@@ -24,10 +29,7 @@ class DatabaseTests(TestCase):
         Category.objects.create(name="ExistingCategory1")
 
     def tearDown(self):
-        for model in LatestModel.objects.all():
-            filepath = f"{settings.MODEL_DIR}/{model.model_id}/{model.revision}.zip"
-            if os.path.exists(filepath):
-                shutil.rmtree(os.path.dirname(filepath))
+        shutil.rmtree(settings.MODEL_DIR)
 
     def _create_dummy_file(self, name="test_model.zip"):
         with open("mainapp/tests/models/test_model.zip", "rb") as f:

--- a/mainapp/utils.py
+++ b/mainapp/utils.py
@@ -35,6 +35,3 @@ CHANGES = {
     0: 'Upload',
     1: 'Revise',
 }
-
-# The directory the models will be stored in
-MODEL_DIR = settings.MODEL_DIR

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -10,7 +10,7 @@ from django.contrib import messages
 from django.db import transaction
 from .models import Model, LatestModel, Comment, Category, Change, Ban, Location
 from .forms import UploadFileForm, UploadFileMetadataForm, MetadataForm
-from .utils import get_kv, update_last_page, get_last_page, MODEL_DIR, CHANGES, admin, LICENSES_DISPLAY
+from .utils import get_kv, update_last_page, get_last_page, CHANGES, admin, LICENSES_DISPLAY
 import mainapp.database as database
 from mainapp.markdown import markdown
 


### PR DESCRIPTION
This PR refactors the codebase by replacing all instances of utils.MODEL_DIR with settings.MODEL_DIR.

This change improves consistency across the project and enables us to use settings_override to specify a temporary MODEL_DIR during tests.