### PR TITLE
Add Unit Test For `get_kv` Function

### DIFF
--- a/mainapp/tests/test_utils.py
+++ b/mainapp/tests/test_utils.py
@@ -4,11 +4,11 @@ from mainapp.utils import get_kv
 class TestUtils(SimpleTestCase):
     def test_tag_with_single_equality(self):
         tag = "key=value"
-        self.assertEquals(get_kv(tag), ["key", "value"])
+        self.assertEqual(get_kv(tag), ["key", "value"])
 
     def test_tag_with_multiple_equality(self):
         tag_a = "key=value=value"
         tag_b = "key=value=val=v"
 
-        self.assertEquals(get_kv(tag_a), ["key", "value=value"])
-        self.assertEquals(get_kv(tag_b), ["key", "value=val=v"])
+        self.assertEqual(get_kv(tag_a), ["key", "value=value"])
+        self.assertEqual(get_kv(tag_b), ["key", "value=val=v"])

--- a/mainapp/tests/test_utils.py
+++ b/mainapp/tests/test_utils.py
@@ -1,0 +1,14 @@
+from django.test import SimpleTestCase
+from mainapp.utils import get_kv
+
+class TestUtils(SimpleTestCase):
+    def test_tag_with_single_equality(self):
+        tag = "key=value"
+        self.assertEquals(get_kv(tag), ["key", "value"])
+
+    def test_tag_with_multiple_equality(self):
+        tag_a = "key=value=value"
+        tag_b = "key=value=val=v"
+
+        self.assertEquals(get_kv(tag_a), ["key", "value=value"])
+        self.assertEquals(get_kv(tag_b), ["key", "value=val=v"])

--- a/mainapp/utils/__init__.py
+++ b/mainapp/utils/__init__.py
@@ -6,7 +6,7 @@ from .model_validator import validate_glb_file
 # Gets the key and value of an OSM tag from a string
 # Note: any extra '=' chars other than the first will be included in the value.
 def get_kv(string):
-    return string.split('=', 2)
+    return string.split('=', 1)
 
 def update_last_page(request):
     request.session['last_page'] = request.get_full_path()


### PR DESCRIPTION
This PR introduces the changes proposed in [merge request 28](https://gitlab.com/n42k/3dmr/-/merge_requests/28) of the legacy repo .

### Issue
`utils.get_kv()` function fails to work as specified in the comment above it.
```python
# Gets the key and value of an OSM tag from a string
# Note: any extra '=' chars other than the first will be included in the value.
def get_kv(string):
    return string.split('=', 2)
```
This would throw `ValueError` when the input tag would resemble `value=val=v` 

### Changes
- Modify get_kv to split only on first occurence of `=`.
- Add tests for the aforementioned.