### PR TITLE
Full screen model preview support, minor UI updates and model stats update

### DIFF
--- a/mainapp/static/mainapp/main.css
+++ b/mainapp/static/mainapp/main.css
@@ -110,19 +110,3 @@ form > #map-descriptor {
 .panel-body.panel-hidden {
 	background-color: #faf0f0;
 }
-
-.stat-good {
-	color: #4CAF50;
-}
-
-.stat-warning {
-	color: #FFC107;
-}
-
-.stat-bad {
-	color: #F44336;
-}
-
-.stat-neutral {
-  color: gray;
-}

--- a/mainapp/static/mainapp/main.css
+++ b/mainapp/static/mainapp/main.css
@@ -110,3 +110,57 @@ form > #map-descriptor {
 .panel-body.panel-hidden {
 	background-color: #faf0f0;
 }
+
+#fullscreen-button,
+#scale-container,
+.axis-label {
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    border-radius: 5px;
+    z-index: 100;
+	position: absolute;
+}
+
+#fullscreen-button {
+    top: 25px;
+    right: 25px;
+    padding: 8px 12px;
+    cursor: pointer;
+    user-select: none;
+}
+#fullscreen-button:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+}
+
+.labels-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 99;
+    display: none;
+}
+
+.axis-label {
+    padding: 2px 6px;
+    border-radius: 3px;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
+}
+
+#scale-container {
+    top: 20px;
+    left: 20px;
+    padding: 12px 16px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+}
+
+.scale-footer {
+    color: #ccc;
+    margin-top: 8px;
+    padding-top: 4px;
+    border-top: 1px solid rgba(255,255,255,0.1);
+}

--- a/mainapp/static/mainapp/model_stats.js
+++ b/mainapp/static/mainapp/model_stats.js
@@ -172,8 +172,6 @@ function updateModelStats(stats) {
     );
 
     document.getElementById("hasAnimations").textContent = stats.hasAnimations ? "Yes" : "No";
-    setStatQualityClass("hasAnimations", stats.hasAnimations ? "good" : "neutral");
-
 }
 
 window.initStatsTHREE = initTHREE;

--- a/mainapp/static/mainapp/model_stats.js
+++ b/mainapp/static/mainapp/model_stats.js
@@ -147,8 +147,7 @@ function setStatQualityClass(id, quality) {
 
 function updateModelStats(stats) {
     const fc = stats.faces;
-    // toLocaleString produces inconsistent decimal seperators across different regions
-    document.getElementById("faceCount").textContent = fc.toLocaleString();
+    document.getElementById("faceCount").textContent = fc.toLocaleString("en-US");
     setStatQualityClass("faceCount", 
         fc <= 5000 ? "good" :
         fc <= 100000 ? "warning" : "bad"
@@ -167,11 +166,11 @@ function updateModelStats(stats) {
     );
 
     const mesh = stats.meshes;
-    document.getElementById("meshCount").textContent = mesh.toLocaleString();
+    document.getElementById("meshCount").textContent = mesh.toLocaleString("en-US");
     setStatQualityClass("meshCount", mesh >= 1 ? "good" : "bad");
 
     const density = stats.triangleDensity;
-    document.getElementById("triangleDensity").innerHTML = density.toLocaleString() + " triangles/m<sup>3</sup>";
+    document.getElementById("triangleDensity").innerHTML = density.toLocaleString("en-US") + " triangles/m<sup>3</sup>";
     setStatQualityClass("triangleDensity", 
         density > 0 && density <= 500 ? "good" :
         density <= 1000 ? "warning" : "bad"

--- a/mainapp/static/mainapp/preview.js
+++ b/mainapp/static/mainapp/preview.js
@@ -9,6 +9,7 @@ let labelsContainer = null;
 let scaleContainer = null;
 let gridSize = 100;
 let boundingBox = {x: 100, y:100, z:100};
+let groundPosition = 0;
 
 function setUpRenderPane(){
 	const elems = document.querySelectorAll('div.render-pane');
@@ -116,6 +117,7 @@ function loadGLB(url, options, three) {
 		const center = bbox.getCenter(new THREE.Vector3());
 		const size = bbox.getSize(new THREE.Vector3());
 		boundingBox = size;
+		groundPosition = -size.y/2 - bbox.min.y;
 
 		object.position.sub(center);
 
@@ -195,11 +197,13 @@ function toggleVisualHelpers(scene, enable) {
 	if (enable) {
 	if (!axesHelper) {
 			axesHelper = new THREE.AxesHelper(gridSize/2);
+			axesHelper.position.y = groundPosition;
 			scene.add(axesHelper);
 		}
 
 		if (!gridHelper) {
 			gridHelper = new THREE.GridHelper(gridSize);
+			gridHelper.position.y = groundPosition;
 			scene.add(gridHelper);
 		}
 
@@ -276,9 +280,9 @@ function updateLabels(camera) {
 
 	const tempV = new THREE.Vector3();
 	const label3DPositions = {
-		x: new THREE.Vector3(gridSize/2, 0, 0),
-		y: new THREE.Vector3(0, gridSize/2, 0),
-		z: new THREE.Vector3(0, 0, gridSize/2),
+		x: new THREE.Vector3(gridSize/2, groundPosition, 0),
+		y: new THREE.Vector3(0, gridSize/2 + groundPosition, 0),
+		z: new THREE.Vector3(0, groundPosition, gridSize/2),
 	};
 
 	for (const axis in {x:true, y:true, z:true}) {

--- a/mainapp/static/mainapp/preview.js
+++ b/mainapp/static/mainapp/preview.js
@@ -126,7 +126,10 @@ function loadGLB(url, options, three) {
 		camera.position.set(center.x, center.y, cameraZ * 1.5);
 		camera.lookAt(new THREE.Vector3(0, 0, 0));
 
-		gridSize = Math.ceil(maxDim / 50) * 50;
+		if (maxDim >= 5)
+			gridSize = Math.ceil(maxDim / 50) * 50;
+		else
+			gridSize = maxDim;
 
 		let mixer = null;
 	
@@ -229,9 +232,9 @@ function toggleVisualHelpers(scene, enable) {
 				
 				for (let i = -5; i <= 5; i++) {
 					const distance = i * gridSpacing;
-					distanceMarkers[`marker_x_${i}`] = createLabelElement(`${distance.toString()}`, '#888');
+					distanceMarkers[`marker_x_${i}`] = createLabelElement(`${distance.toFixed(1)}`, '#888');
 					labelsContainer.appendChild(distanceMarkers[`marker_x_${i}`]);
-					distanceMarkers[`marker_z_${i}`] = createLabelElement(`${distance.toString()}`, '#888');
+					distanceMarkers[`marker_z_${i}`] = createLabelElement(`${distance.toFixed(1)}`, '#888');
 					labelsContainer.appendChild(distanceMarkers[`marker_z_${i}`]);
 				}
 			}
@@ -243,7 +246,7 @@ function toggleVisualHelpers(scene, enable) {
 			if (!gridSize) return;
 
 			const gridSpacingEl = document.getElementById('grid-spacing-value');
-			if (gridSpacingEl) gridSpacingEl.textContent = `${gridSpacing.toString()}m`;
+			if (gridSpacingEl) gridSpacingEl.textContent = `${gridSpacing.toFixed(1)}m`;
 		}
 	} else {
 		if (axesHelper) {

--- a/mainapp/static/mainapp/preview.js
+++ b/mainapp/static/mainapp/preview.js
@@ -2,6 +2,14 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
+let axesHelper = null;
+let gridHelper = null;
+let htmlLabels = {};
+let labelsContainer = null;
+let scaleContainer = null;
+let gridSize = 100;
+let boundingBox = {x: 100, y:100, z:100};
+
 function setUpRenderPane(){
 	const elems = document.querySelectorAll('div.render-pane');
 
@@ -29,7 +37,7 @@ function initTHREE(elementId, options) {
 	if(typeof options['height'] === 'undefined')
 		options['height'] = renderPane.clientHeight;
 
-	const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+	const renderer = new THREE.WebGLRenderer({ antialias: true });
 	renderer.setPixelRatio(window.devicePixelRatio);
 	renderer.setSize(options['width'], options['height']);
 	renderer.outputEncoding = THREE.sRGBEncoding;
@@ -79,7 +87,8 @@ function initTHREE(elementId, options) {
 		'scene': scene,
 		'camera': camera,
 		'renderer': renderer,
-		'controls': controls
+		'controls': controls,
+		'renderPane': renderPane,
 	}
 }
 
@@ -91,6 +100,7 @@ function loadGLB(url, options, three) {
 		const camera = three.camera;
 		const renderer = three.renderer;
 		const controls = three.controls;
+		const renderPane = three.renderPane;
 
 		const object = gltf.scene;
 		scene.add(object);
@@ -105,6 +115,7 @@ function loadGLB(url, options, three) {
 		const bbox = new THREE.Box3().setFromObject(object);
 		const center = bbox.getCenter(new THREE.Vector3());
 		const size = bbox.getSize(new THREE.Vector3());
+		boundingBox = size;
 
 		object.position.sub(center);
 
@@ -113,6 +124,8 @@ function loadGLB(url, options, three) {
 		const cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
 		camera.position.set(center.x, center.y, cameraZ * 1.5);
 		camera.lookAt(new THREE.Vector3(0, 0, 0));
+
+		gridSize = maxDim;
 
 		let mixer = null;
 	
@@ -123,13 +136,15 @@ function loadGLB(url, options, three) {
 			});
 		}
 
-		animate(renderer, scene, camera, controls, options, mixer);
+		setupFullscreenButton(three);
+
+		animate(renderer, scene, camera, controls, options, mixer, renderPane);
 	}, undefined, function(error) {
 		console.error("Error loading GLB:", error);
 	});
 }
 
-function animate(renderer, scene, camera, controls, options, mixer) {
+function animate(renderer, scene, camera, controls, options, mixer, renderPane) {
 	// clock instance needs to be outside the animation
 	// loop to ensure consistency with the mixer 
 	const clock = new THREE.Clock();
@@ -141,8 +156,14 @@ function animate(renderer, scene, camera, controls, options, mixer) {
 
 		if (mixer) mixer.update(delta);
 
-		resizeCanvas(renderer, camera, options);
+		resizeCanvas(renderer, camera, options, renderPane);
+
 		controls.update();
+
+		if (document.fullscreenElement) {
+			updateLabels(camera);
+		}
+
 		renderer.render(scene, camera);
 	}
 
@@ -150,17 +171,164 @@ function animate(renderer, scene, camera, controls, options, mixer) {
 }
 
 
-function resizeCanvas(renderer, camera, options) {
+function resizeCanvas(renderer, camera, options, renderPane) {
 	const canvas = renderer.domElement;
 
-	const width = options['width'];
-	const height = options['height'];
+	canvas.style = null;
+	let width, height;
+	if (document.fullscreenElement === renderPane) {
+		width = window.innerWidth; 
+		height = window.innerHeight;
+	} else {
+		width = options['width'];
+		height = options['height'];
+	}
 
 	if(canvas.width != width || canvas.height != height) {
 		renderer.setSize(width, height, false);
 		camera.aspect = width/height;
 		camera.updateProjectionMatrix();
 	}
+}
+
+function toggleVisualHelpers(scene, enable) {
+	if (enable) {
+	if (!axesHelper) {
+			axesHelper = new THREE.AxesHelper(gridSize/2);
+			scene.add(axesHelper);
+		}
+
+		if (!gridHelper) {
+			gridHelper = new THREE.GridHelper(gridSize);
+			scene.add(gridHelper);
+		}
+
+		labelsContainer = document.getElementById('labels-container');
+		if (labelsContainer) {
+			labelsContainer.style.display = 'block';
+			if (Object.keys(htmlLabels).length === 0) {
+				labelsContainer = document.getElementById('labels-container');
+				if (!labelsContainer) return;
+
+				labelsContainer.innerHTML = '';
+				htmlLabels = {};
+
+				htmlLabels.x = createLabelElement('X', 'red');
+				htmlLabels.y = createLabelElement('Y', 'green');
+				htmlLabels.z = createLabelElement('Z', 'blue');
+				labelsContainer.appendChild(htmlLabels.x);
+				labelsContainer.appendChild(htmlLabels.y);
+				labelsContainer.appendChild(htmlLabels.z);
+			}
+		}
+
+		scaleContainer = document.getElementById('scale-container');
+		if (scaleContainer) {
+			scaleContainer.style.display = 'block';
+			if (!gridSize) return;
+
+			const gridSpacing = gridSize / 10;
+			const totalSize = boundingBox.x * boundingBox.y * boundingBox.z;
+			
+			const gridSizeEl = document.getElementById('grid-size-value');
+			const gridSpacingEl = document.getElementById('grid-spacing-value');
+			const squareSizeEl = document.getElementById('square-size-value');
+			const modelSpaceEl = document.getElementById('model-space-value');
+			
+			if (gridSizeEl) gridSizeEl.textContent = `${gridSize.toFixed(1)}m`;
+			if (gridSpacingEl) gridSpacingEl.textContent = `${gridSpacing.toFixed(1)}m`;
+			if (squareSizeEl) squareSizeEl.textContent = `${gridSpacing.toFixed(1)}m × ${gridSpacing.toFixed(1)}m`;
+			if (modelSpaceEl) modelSpaceEl.innerHTML = `${totalSize.toFixed(0)}m<sup>3</sup>`;
+		}
+	} else {
+		if (axesHelper) {
+			scene.remove(axesHelper);
+			axesHelper.dispose();
+			axesHelper = null;
+		}
+
+		if (gridHelper) {
+			scene.remove(gridHelper);
+			gridHelper.dispose();
+			gridHelper = null;
+		}
+
+		if (labelsContainer) {
+			labelsContainer.style.display = 'none';
+		}
+
+		if (scaleContainer) {
+			scaleContainer.style.display = 'none';
+		}
+	}
+}
+
+function createLabelElement(text, color) {
+	const div = document.createElement('div');
+	div.className = 'axis-label';
+	div.style.color = color;
+	div.textContent = text;
+	return div;
+}
+
+function updateLabels(camera) {
+	if (!labelsContainer || labelsContainer.style.display === 'none' || !camera) return;
+
+	const tempV = new THREE.Vector3();
+	const label3DPositions = {
+		x: new THREE.Vector3(gridSize/2, 0, 0),
+		y: new THREE.Vector3(0, gridSize/2, 0),
+		z: new THREE.Vector3(0, 0, gridSize/2),
+	};
+
+	for (const axis in {x:true, y:true, z:true}) {
+		const label = htmlLabels[axis];
+		const position = label3DPositions[axis];
+
+		tempV.copy(position);
+		tempV.project(camera);
+
+		const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
+		const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
+
+		label.style.left = `${x}px`;
+		label.style.top = `${y}px`;
+	}
+
+}
+
+function handleFullscreenChange(threeInstance) {
+	const renderPane = document.querySelector('.render-pane');
+	const isFullscreen = document.fullscreenElement === renderPane;
+
+	if (isFullscreen) {
+		console.log('Entered fullscreen for render-pane');
+		toggleVisualHelpers(threeInstance.scene, true);
+	} else {
+		console.log('Exited fullscreen for render-pane');
+		toggleVisualHelpers(threeInstance.scene, false);
+	}
+	
+	resizeCanvas(threeInstance.renderer, threeInstance.camera, {}, renderPane);
+}
+
+function setupFullscreenButton(threeInstance) {
+	const fullscreenButton = document.getElementById('fullscreen-button');
+	if (!fullscreenButton) return;
+
+	fullscreenButton.addEventListener('click', function (event) {
+		const renderPane = document.querySelector('.render-pane');
+
+		if (!document.fullscreenElement && renderPane.requestFullscreen) {
+			renderPane.requestFullscreen();
+		} else if (document.exitFullscreen) {
+			document.exitFullscreen();
+		}
+	});
+
+	document.addEventListener('fullscreenchange', function (event) {
+		handleFullscreenChange(threeInstance);
+	});
 }
 
 window.setUpRenderPane = setUpRenderPane;

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -15,7 +15,6 @@
 <div class="container">
 	<div class="col-12">
 		<h1>3D Model Repository</h1>
-        <p>This is a repository for storing models for use in OSM 3D visualizers. Login using OSM OAuth on the top right. There is a <a href="https://wiki.openstreetmap.org/wiki/3D_Model_Repository">wiki page</a> and a <a href="https://gitlab.com/n42k/3dmr">GitLab repository</a> available. You may also express your thoughts on the <a href="https://forum.openstreetmap.org/viewtopic.php?pid=677724">3D subforum</a> of the OSM forums.</p>
 	</div>
 	<hr>
 	<div class="row flex">

--- a/mainapp/templates/mainapp/layout.html
+++ b/mainapp/templates/mainapp/layout.html
@@ -75,6 +75,14 @@
 	{% endif %}
 	{% block body %}
 	{% endblock %}
+
+	<nav class="navbar-fixed-bottom">
+		<div class="container-fluid text-right">
+			<a class="item" target="_blank" href="https://wiki.openstreetmap.org/wiki/3D_Model_Repository">Wiki Page</a>
+			<span class="separator" aria-hidden="true">|</span>
+			<a class="item" target="_blank" href="https://github.com/fossgis/3dmr">GitHub</a>
+		</div>
+	</nav>
 	<script src="{% static 'mainapp/lib/jquery.min.js' %}"></script>
 	<script src="{% static 'mainapp/lib/bootstrap.min.js' %}"></script>
 	{% block footeradditions %}

--- a/mainapp/templates/mainapp/layout.html
+++ b/mainapp/templates/mainapp/layout.html
@@ -40,6 +40,7 @@
 			</div>
 			<div id="navbar" class="navbar-collapse collapse in" aria-expanded="true" style role="menu">
 				<ul class="nav navbar-nav navbar-right">
+					<li><a href="https://wiki.openstreetmap.org/wiki/3D_Model_Repository">Documentation</a></li>
 					<li><a href="{% url 'docs' %}">API Docs</a></li>
 					<li><a href="{% url 'downloads' %}">Downloads</a></li>
 					<li><a href="{% url 'map' %}">Map</a></li>
@@ -78,7 +79,7 @@
 
 	<nav class="navbar-fixed-bottom">
 		<div class="container-fluid text-right">
-			<a class="item" target="_blank" href="https://wiki.openstreetmap.org/wiki/3D_Model_Repository">Wiki Page</a>
+			<a class="item" target="_blank" href="https://community.openstreetmap.org/tag/3d">3D Forum</a>
 			<span class="separator" aria-hidden="true">|</span>
 			<a class="item" target="_blank" href="https://github.com/fossgis/3dmr">GitHub</a>
 		</div>

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -43,21 +43,8 @@
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
-								<div>
-									<span>Grid Size:</span> 
-									<span id="grid-size-value">-</span>
-								</div>
-								<div>
-									<span>Grid Spacing:</span> 
-									<span id="grid-spacing-value">-</span>
-								</div>
-								<div>
-									<span>Each Square:</span> 
-									<span id="square-size-value">-</span>
-								</div>
-								<div class="scale-footer">
-									Model fits in <span id="model-space-value">-</span> space
-								</div>
+								<span>Grid Spacing:</span> 
+								<span id="grid-spacing-value">-</span>
 							</div>
 						</div>
 					</div>
@@ -212,10 +199,6 @@ initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }},
 	window.addEventListener("load", function() {
 		setUpRenderPane();
 		setUpStats();
-	});
-
-	$(function () {
-		$('[data-toggle="tooltip"]').tooltip();
 	});
 </script>
 {% endcompress %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -194,6 +194,10 @@ initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }},
 		setUpRenderPane();
 		setUpStats();
 	});
+
+	$(function () {
+		$('[data-toggle="tooltip"]').tooltip();
+	});
 </script>
 {% endcompress %}
 {% endblock %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -40,6 +40,25 @@
 				<div class="tab-content" style="overflow: hidden;">
 					<div class="tab-pane active" id="view" role="tabpanel">
 						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}" id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
+							<div id="fullscreen-button">&#x26F6;</div>
+							<div id="labels-container"></div>
+							<div id="scale-container" style="display: none;">
+								<div>
+									<span>Grid Size:</span> 
+									<span id="grid-size-value">-</span>
+								</div>
+								<div>
+									<span>Grid Spacing:</span> 
+									<span id="grid-spacing-value">-</span>
+								</div>
+								<div>
+									<span>Each Square:</span> 
+									<span id="square-size-value">-</span>
+								</div>
+								<div class="scale-footer">
+									Model fits in <span id="model-space-value">-</span> space
+								</div>
+							</div>
 						</div>
 					</div>
 					{% if model.location %}

--- a/mainapp/templates/mainapp/model_stats.html
+++ b/mainapp/templates/mainapp/model_stats.html
@@ -1,9 +1,13 @@
-<p>Faces: <span id="faceCount" class="stat-neutral">-</span></p>
-<p>Meshes: <span id="meshCount" class="stat-neutral">-</span></p>
-<p>Triangle Density: <span id="triangleDensity" class="stat-neutral">-</span></p>
-<p>Materials: <span id="materialCount" class="stat-neutral">-</span></p>
-<p>Bounding Box (W × H × D): <span id="boundingBox" class="stat-neutral">-</span></p>
-<p>Model Scale (X × Y × Z): <span id="modelScale" class="stat-neutral">-</span></p>
-<p>Animations Present: <span id="hasAnimations" class="stat-neutral">-</span></p>
-
-
+<p>Faces: <span id="faceCount" class="text-muted">-</span></p>
+<p>Meshes: <span id="meshCount" class="text-muted">-</span></p>
+<p>Triangle Density: <span id="triangleDensity" class="text-muted">-</span></p>
+<p>Bounding Box (W × H × D): <span id="boundingBox" class="text-muted">-</span></p>
+<p> 
+    <span href="#" 
+        data-toggle="tooltip" 
+        title="Calculated based on the number of materials and PBR textures. Higher scores indicate better visual richness.">
+        Visual Detail Score:
+    </span>
+    <span id="visualDetailScore" class="text-muted">-</span>
+</p>
+<p>Animations Present: <span id="hasAnimations" class="text-muted">-</span></p>

--- a/mainapp/templates/mainapp/model_stats.html
+++ b/mainapp/templates/mainapp/model_stats.html
@@ -2,12 +2,6 @@
 <p>Meshes: <span id="meshCount" class="text-muted">-</span></p>
 <p>Triangle Density: <span id="triangleDensity" class="text-muted">-</span></p>
 <p>Bounding Box (W × H × D): <span id="boundingBox" class="text-muted">-</span></p>
-<p> 
-    <span href="#" 
-        data-toggle="tooltip" 
-        title="Calculated based on the number of materials and PBR textures. Higher scores indicate better visual richness.">
-        Visual Detail Score:
-    </span>
-    <span id="visualDetailScore" class="text-muted">-</span>
-</p>
+<p>Textures Present: <span id="hasTextures" class="text-muted">-</span></p>
+<p>PBR Textures: <span id="PBRTextureCount" class="text-muted">-</span></p>
 <p>Animations Present: <span id="hasAnimations" class="text-muted">-</span></p>

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -225,6 +225,11 @@
 			document.getElementById("model-preview").style.display = "none";
 		}
 	});
+
+
+	$(function () {
+		$('[data-toggle="tooltip"]').tooltip();
+	});
 </script>
 {% endcompress %}
 {% endif %}

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -10,6 +10,7 @@
 		{% for error in form.title.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		{{ form.title }}
 	</div>
+	{% endif %}
 	{% if form_file %}
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
@@ -18,10 +19,29 @@
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
 		<div class="tab-content" style="overflow: hidden; display: flex; align-items: flex-start;">
-			
-			<div id="view" role="tabpanel" style="margin-right: 20px;">
-				<b style="margin: 0 0 8px 0;">3D Preview</b>
-				<div class="render-pane" id="render-pane" style="height: 300px;"></div>
+			<div id="view" class="col-md-4" role="tabpanel">
+				<b style="margin-bottom: 8px;">3D Preview</b>
+				<div class="render-pane" id="render-pane">
+					<div id="fullscreen-button">&#x26F6;</div>
+					<div id="labels-container"></div>
+					<div id="scale-container" style="display: none;">
+						<div>
+							<span>Grid Size:</span> 
+							<span id="grid-size-value">-</span>
+						</div>
+						<div>
+							<span>Grid Spacing:</span> 
+							<span id="grid-spacing-value">-</span>
+						</div>
+						<div>
+							<span>Each Square:</span> 
+							<span id="square-size-value">-</span>
+						</div>
+						<div class="scale-footer">
+							Model fits in <span id="model-space-value">-</span> space
+						</div>
+					</div>
+				</div>
 			</div>
 
 			<div id="model-stats" role="tabpanel">
@@ -33,6 +53,7 @@
 	</div>
 	<div id="model-status"></div>
 	{% endif %}
+	{% if form_metadata %}
 	<div class="form-group">
 		<label for="{{ form.description.id_for_label }}">{{ form.description.label }}:</label>
 		{% for error in form.description.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
@@ -217,11 +238,15 @@
 
 			initStatsTHREE(fileURL);
 			
-			const options = {"width": "350", "height": "300"}
+			const options = {"width": "400", "height": "350"}
 			
 			const renderPane = document.getElementById("render-pane");
-			while (renderPane.firstChild) {
-				renderPane.removeChild(renderPane.firstChild);
+			const canvases = document.getElementsByTagName("canvas");
+
+			for (const element of canvases) {
+				if (renderPane.contains(element)) {
+					renderPane.removeChild(element);
+				}
 			}
 			
 			displayPreview("render-pane", fileURL, options);

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -25,21 +25,8 @@
 					<div id="fullscreen-button">&#x26F6;</div>
 					<div id="labels-container"></div>
 					<div id="scale-container" style="display: none;">
-						<div>
-							<span>Grid Size:</span> 
-							<span id="grid-size-value">-</span>
-						</div>
-						<div>
-							<span>Grid Spacing:</span> 
-							<span id="grid-spacing-value">-</span>
-						</div>
-						<div>
-							<span>Each Square:</span> 
-							<span id="square-size-value">-</span>
-						</div>
-						<div class="scale-footer">
-							Model fits in <span id="model-space-value">-</span> space
-						</div>
+						<span>Grid Spacing:</span> 
+						<span id="grid-spacing-value">-</span>
 					</div>
 				</div>
 			</div>
@@ -253,11 +240,6 @@
 		} else {
 			document.getElementById("model-preview").style.display = "none";
 		}
-	});
-
-
-	$(function () {
-		$('[data-toggle="tooltip"]').tooltip();
 	});
 </script>
 {% endcompress %}

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -10,6 +10,29 @@
 		{% for error in form.title.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		{{ form.title }}
 	</div>
+	{% if form_file %}
+	<div class="form-group required">
+		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
+		{% for error in form.model_file.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
+		{{ form.model_file }}
+	</div>
+	<div id="model-preview" style="margin-bottom: 15px; display: none;">
+		<div class="tab-content" style="overflow: hidden; display: flex; align-items: flex-start;">
+			
+			<div id="view" role="tabpanel" style="margin-right: 20px;">
+				<b style="margin: 0 0 8px 0;">3D Preview</b>
+				<div class="render-pane" id="render-pane" style="height: 300px;"></div>
+			</div>
+
+			<div id="model-stats" role="tabpanel">
+				<b style="margin: 0 0 8px 0;">Model Stats</b>
+				{% include 'mainapp/model_stats.html' %}
+			</div>
+
+		</div>
+	</div>
+	<div id="model-status"></div>
+	{% endif %}
 	<div class="form-group">
 		<label for="{{ form.description.id_for_label }}">{{ form.description.label }}:</label>
 		{% for error in form.description.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
@@ -25,19 +48,23 @@
 		{% for error in form.categories.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		{{ form.categories }}
 	</div>
+	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
-	<div class="form-group">
-		<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
-		{% for error in form.latitude.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
-		<div class="alert alert-danger" role="alert" id="latitude-error" style="display: none;"></div>
-		{{ form.latitude }}
-	</div>
-	<div class="form-group">
-		<label for="{{ form.longitude.id_for_label }}">{{ form.longitude.label }}:</label>
-		{% for error in form.longitude.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
-		<div class="alert alert-danger" role="alert" id="longitude-error" style="display: none;"></div>
-		{{ form.longitude }}
+	
+	<div class="row flex" style="justify-content: space-between;">
+		<div class="form-group" style="width: 45%;">
+			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
+			{% for error in form.latitude.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
+			<div class="alert alert-danger" role="alert" id="latitude-error" style="display: none;"></div>
+			{{ form.latitude }}
+		</div>
+		<div class="form-group" style="width: 45%;">
+			<label for="{{ form.longitude.id_for_label }}">{{ form.longitude.label }}:</label>
+			{% for error in form.longitude.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
+			<div class="alert alert-danger" role="alert" id="longitude-error" style="display: none;"></div>
+			{{ form.longitude }}
+		</div>
 	</div>
 	<span class="help-block">It's preferable to change the transformations of your model instead of using these fields.</span>
 	<div class="form-group">
@@ -70,29 +97,6 @@
 		{% endfor %}
 	</div>
 	{% endif %}
-	{% if form_file %}
-	<div class="form-group required">
-		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
-		{% for error in form.model_file.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
-		{{ form.model_file }}
-	</div>
-	<div id="model-preview" style="margin-bottom: 15px; display: none;">
-		<div class="tab-content" style="overflow: hidden; display: flex; align-items: flex-start;">
-			
-			<div id="view" role="tabpanel" style="margin-right: 20px;">
-				<b style="margin: 0 0 8px 0;">3D Preview</b>
-				<div class="render-pane" id="render-pane" style="height: 240px;"></div>
-			</div>
-
-			<div id="model-stats" role="tabpanel">
-				<b style="margin: 0 0 8px 0;">Model Stats</b>
-				{% include 'mainapp/model_stats.html' %}
-			</div>
-
-		</div>
-	</div>
-	<div id="model-status"></div>
-	{% endif %}
 	<div class="alert alert-danger" role="alert" id="form-error" style="display: none;"></div>
 	<button type="submit" class="btn btn-default">{% if revise %}Revise Model{% elif edit %}Edit Metadata{% else %}Upload Model{% endif %}</button>
 </form>
@@ -113,7 +117,7 @@
 	var map = L.map('map');
 	map.on('load', function() {
 		var descriptor = document.getElementById('map-descriptor');
-		descriptor.innerHTML = 'Click anywhere on the map to set longitude/latitude values.';
+		descriptor.innerHTML = 'Click anywhere on the map to set approximate longitude/latitude values.<br/>This will only be attached to the model\'s metadata.';
 	});
 	map.setView([51.505, -0.09], 3);
 
@@ -213,7 +217,7 @@
 
 			initStatsTHREE(fileURL);
 			
-			const options = {"width": "240", "height": "240"}
+			const options = {"width": "350", "height": "300"}
 			
 			const renderPane = document.getElementById("render-pane");
 			while (renderPane.firstChild) {


### PR DESCRIPTION
## This PR introduces following changes

* Replaced material count with a new custom combined metrics `visualDetailScore = material count + 1.5 * texture count`; good if > 5 bad if == 0, in between warning.

* Removed model scale display

* Removed animation presence based color feedback

* Added units to stat values

* Replaced custom CSS feedback classes with Bootstrap's `text-success`, `text-warning`, `text-danger`

* Updated location helper text on the upload page

* Added bottom navbar with GitHub and Wiki links

#### Fullscreen mode (model page + upload form model-preview):

* Added axis helper
* Added grid helper
* Displayed scale metrics on top left
