### PR TITLE
Admin Moderation Tools

### DIFF
--- a/mainapp/database.py
+++ b/mainapp/database.py
@@ -1,6 +1,6 @@
 import os
 import logging
-import mistune
+import shutil
 
 from django.db import transaction
 from django.conf import settings
@@ -166,4 +166,23 @@ def edit(options):
     except:
         logger.exception('Fatal server error when editing metadata.')
 
+        return False
+
+def delete(model_id):
+    try:
+        with transaction.atomic():
+            models = Model.objects.filter(model_id=model_id)
+            if not models.exists():
+                logger.exception(None, 'Model does not exist.')
+                return False
+            for m in models:
+                path = '{}/{}'.format(settings.MODEL_DIR, m.model_id)
+                if os.path.exists(path):
+                    shutil.rmtree(path)
+            
+            models.delete()
+            logger.info('Model deleted successfully.')
+            return True
+    except Exception as e:
+        logger.exception('Fatal server error when deleting model.')
         return False

--- a/mainapp/database.py
+++ b/mainapp/database.py
@@ -172,15 +172,20 @@ def delete(model_id):
     try:
         with transaction.atomic():
             models = Model.objects.filter(model_id=model_id)
+            changes = Change.objects.filter(model__model_id=model_id)
+
             if not models.exists():
                 logger.exception(None, 'Model does not exist.')
                 return False
+            
             for m in models:
                 path = '{}/{}'.format(settings.MODEL_DIR, m.model_id)
                 if os.path.exists(path):
                     shutil.rmtree(path)
             
+            changes.delete()
             models.delete()
+            
             logger.info('Model deleted successfully.')
             return True
     except Exception as e:

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -109,18 +109,27 @@
 					{% if model.is_hidden %}
 					<strong>This model is hidden</strong>
 					{% endif %}
-					<form action="{% url 'hide_model' %}" method="post">
-						{% csrf_token %}
-						<input type="hidden" name="model_id" value="{{ model.model_id }}">
-						<input type="hidden" name="revision" value="{{ model.revision }}">
-						{% if model.is_hidden %}
-						<input type="hidden" name="type" value="unhide">
-						<button type="submit" class="btn btn-danger">Unhide Model</button>
-						{% else %}
-						<input type="hidden" name="type" value="hide">
-						<button type="submit" class="btn btn-danger">Hide Model</button>
-						{% endif %}
-					</form>
+					<p>
+						<form action="{% url 'hide_model' %}" method="post">
+							{% csrf_token %}
+							<input type="hidden" name="model_id" value="{{ model.model_id }}">
+							<input type="hidden" name="revision" value="{{ model.revision }}">
+							{% if model.is_hidden %}
+							<input type="hidden" name="type" value="unhide">
+							<button type="submit" class="btn btn-danger">Unhide Model</button>
+							{% else %}
+							<input type="hidden" name="type" value="hide">
+							<button type="submit" class="btn btn-danger">Hide Model</button>
+							{% endif %}
+						</form>
+					</p>
+					<p>
+						<form action="{% url 'delete_model' %}" method="post">
+							{% csrf_token %}
+							<input type="hidden" name="model_id" value="{{ model.model_id }}">
+							<button type="submit" class="btn btn-danger">Delete Model</button>
+						</form>
+					</p>
 					{% endif %}
 				</div>
 			</div>

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -126,7 +126,7 @@
 						</form>
 					</p>
 					<p>
-						<form action="{% url 'delete_model' %}" method="post">
+						<form action="{% url 'delete_model' %}" method="post" onsubmit="return confirmDeleteModel()">
 							{% csrf_token %}
 							<input type="hidden" name="model_id" value="{{ model.model_id }}">
 							<button type="submit" class="btn btn-danger">Delete Model</button>
@@ -166,5 +166,9 @@ initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }},
 		setUpRenderPane();
 		setUpStats();
 	});
+
+	confirmDeleteModel = function() {
+		return confirm("Are you sure you want to delete this model? This action cannot be undone.");
+	};
 </script>
 {% endblock %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -101,8 +101,10 @@
 					{% endif %}
 					<p>{{ license }}</p>
 					<a href="{% url 'get_model' model.model_id model.revision %}" class="btn btn-default" role="button">Download</a>
-					{% if user.is_authenticated and model.author == user %}
+					{% if user.is_authenticated and model.author == user or user.profile.is_admin %}
 					<a href="{% url 'edit' model.model_id model.revision %}" class="btn btn-default" role="button">Edit Metadata</a>
+					{% endif %}
+					{% if user.is_authenticated and model.author == user %}
 					<a href="{% url 'revise' model.model_id %}" class="btn btn-default" role="button">Revise</a>
 					{% endif %}
 					{% if user.is_authenticated and user.profile.is_admin %}

--- a/mainapp/urls.py
+++ b/mainapp/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     re_path(r'^action/editprofile$', views.editprofile, name='editprofile'),
     re_path(r'^action/ban$', views.ban, name='ban'),
     re_path(r'^action/hide_model$', views.hide_model, name='hide_model'),
+    re_path(r'^action/delete_model$', views.delete_model, name='delete_model'),
 
     re_path(r'^api/info/(?P<model_id>[0-9]+)$', api.get_info, name='get_info'),
 

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -150,8 +150,8 @@ def edit(request, model_id, revision):
         if not request.user.is_authenticated:
             messages.error(request, 'You must be logged in to use this feature.')
             return redirect(index)
-        elif request.user != m.author:
-            messages.error(request, 'You must be the author of the model to edit it.')
+        elif request.user != m.author and not admin(request):
+            messages.error(request, 'You must be the author of the model or an admin user to edit the model.')
             return redirect(model, model_id=m.model_id, revision=m.revision)
         elif form.is_valid():
             status = database.edit({
@@ -178,8 +178,8 @@ def edit(request, model_id, revision):
     else:
         if not request.user.is_authenticated:
             return redirect(index)
-        elif request.user != m.author:
-            messages.error(request, 'You must be the author of the model to edit it.')
+        elif request.user != m.author and not admin(request):
+            messages.error(request, 'You must be the author of the model or an admin user to edit the model.')
             return redirect(model, model_id=m.model_id, revision=m.revision)
 
         tags = []


### PR DESCRIPTION
Introduces new admin priviledges:

- allows admin users to delete models, in addition to the hide model feature
  deleting a model deletes all it's revisions and the model's glb files
  hiding a model hides that specific revision
- allows admin users to edit metadata of any model