### PR TITLE
Udpate Texture Classification

### DIFF
--- a/mainapp/static_src/src/model_stats.js
+++ b/mainapp/static_src/src/model_stats.js
@@ -77,17 +77,17 @@ function calculateModelStats(model, animations) {
                     'roughnessMap',
                     'normalMap',
                     'aoMap',
-                    'map',
                     'emissiveMap',
+                    'clearcoatMap',
+                    'clearcoatRoughnessMap',
+                    'clearcoatNormalMap',
                 ];
                 const otherTextures = [
+                    'map',
                     'bumpMap',
                     'displacementMap',
                     'alphaMap',
                     'envMap',
-                    'clearcoatMap',
-                    'clearcoatRoughnessMap',
-                    'clearcoatNormalMap',
                     'sheenColorMap',
                     'specularMap'
                 ];


### PR DESCRIPTION
Closes #43 

Moves `map` from `PBRTextures` to `otherTextures`; moves `clearcoatMap`, `clearcoatRoughnessMap` and `clearcoatNormalMap`  from `otherTextures` to `PBRTextures`