### PR TITLE
Use rglob instead of glob for recursive OBJ file search

### DIFF
--- a/mainapp/management/commands/obj2glb.py
+++ b/mainapp/management/commands/obj2glb.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
                 logger.error(f"Bad zip file: {zip_path}")
                 continue
 
-            obj_files = list(workdir.glob("*.obj"))
+            obj_files = list(workdir.rglob("*.obj"))
             if not obj_files:
                 logger.warning(f"No OBJ file found in {zip_path} — skipping.")
                 continue


### PR DESCRIPTION
This PR corresponds to the issue as discussed in #54.
This PR updates obj2glb management script to search for OBJ files recursively in the zip to address some outlier models having subdirectory inside model zip.