### PR TITLE
Adds `delete revision` option for admin

### DIFF
--- a/mainapp/database.py
+++ b/mainapp/database.py
@@ -158,11 +158,13 @@ def edit(options):
 
         return False
 
-def delete(model_id):
+def delete(model_id, revision=None):
     try:
         with transaction.atomic():
-            models = Model.objects.filter(model_id=model_id)
-            changes = Change.objects.filter(model__model_id=model_id)
+            if not revision:
+                models = Model.objects.filter(model_id=model_id)
+            else:
+                models = Model.objects.filter(model_id=model_id, revision=revision)
 
             if not models.exists():
                 logger.exception(None, 'Model does not exist.')
@@ -173,7 +175,6 @@ def delete(model_id):
                 if os.path.exists(path):
                     shutil.rmtree(path)
             
-            changes.delete()
             models.delete()
             
             logger.info('Model deleted successfully.')

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -129,7 +129,12 @@
 						<form action="{% url 'delete_model' %}" method="post" onsubmit="return confirmDeleteModel()">
 							{% csrf_token %}
 							<input type="hidden" name="model_id" value="{{ model.model_id }}">
+							{% if not latest_page %}
+							<input type="hidden" name="revision" value="{{ model.revision }}">
+							<button type="submit" class="btn btn-danger">Delete Revision</button>
+							{% else %}
 							<button type="submit" class="btn btn-danger">Delete Model</button>
+							{% endif %}
 						</form>
 					</p>
 					{% endif %}


### PR DESCRIPTION
Closes #54 

This PR introduces `Delete Revision` feature when the admin is on page `/model/<model_id>/<revision>`; and continues showing `Delete Model` option when the admin is on page `/model/<model_id>` instead. 