### PR TITLE
Fix: make_admin command - save `profile` instance instead of `user`

### DIFF
--- a/mainapp/management/commands/make_admin.py
+++ b/mainapp/management/commands/make_admin.py
@@ -74,14 +74,14 @@ class Command(BaseCommand):
                 if dismiss:
                     if user.profile.is_admin:
                         user.profile.is_admin = False
-                        updated_fields.append('profile__is_admin')
+                        updated_fields.append('is_admin')
                 else:
                     if not user.profile.is_admin:
                         user.profile.is_admin = True
-                        updated_fields.append('profile__is_admin')
+                        updated_fields.append('is_admin')
                 
                 if updated_fields:
-                    user.save(update_fields=updated_fields)
+                    user.profile.save(update_fields=updated_fields)
                     action = "dismissed from admin" if dismiss else "made admin"
                     logger.info(
                         f"Successfully {action} for user '{user.username}'. "


### PR DESCRIPTION
The reverse lookup update of `profile__is_admin` from `user` model seems to be having issues on some systems.
Instead of using a reverse relation lookup, we can fetch the `user.profile` instance instead and update directly the `profile` instance for a more reliable update.