### PR TITLE
Adjust padding for panel-body in model page

### DIFF
--- a/mainapp/static_src/public/mainapp/main.css
+++ b/mainapp/static_src/public/mainapp/main.css
@@ -171,9 +171,6 @@ form > #map-descriptor {
     border-top: 1px solid rgba(255,255,255,0.1);
 }
 
-.panel-body {
-    padding: 0;
-}
 .panel-body .tab-content {
     padding: 15px;
     border-top: 1px solid #ddd;

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -78,7 +78,7 @@
 						
 					</h3>
 				</div>
-					<div class="panel-body">
+					<div class="panel-body" style="padding:0px;">
 						<ul class="nav nav-tabs" role="tablist">
 							<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
 							<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>


### PR DESCRIPTION
Avoid global `padding:0px` and add inline CSS for new model page padding rule.