### PR TITLE
Refactor preview.js and model_stats.js

### DIFF
--- a/mainapp/static_src/src/main.js
+++ b/mainapp/static_src/src/main.js
@@ -1,7 +1,2 @@
-import { ModelPreview, setUpRenderPane, displayPreview } from './preview.js';
+import './preview.js';
 import './model_stats.js';
-
-window.ModelPreview = ModelPreview;
-window.setUpRenderPane = setUpRenderPane;
-window.displayPreview = displayPreview;
-

--- a/mainapp/static_src/src/main.js
+++ b/mainapp/static_src/src/main.js
@@ -1,2 +1,7 @@
-import './preview.js';
+import { ModelPreview, setUpRenderPane, displayPreview } from './preview.js';
 import './model_stats.js';
+
+window.ModelPreview = ModelPreview;
+window.setUpRenderPane = setUpRenderPane;
+window.displayPreview = displayPreview;
+

--- a/mainapp/static_src/src/model_stats.js
+++ b/mainapp/static_src/src/model_stats.js
@@ -1,191 +1,156 @@
 import * as THREE from "three";
-import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
 
-function setUpStats() {
-    const elems = document.querySelectorAll('div.render-pane');
+class ModelStats {
+    constructor() {
+        this.stats = null;
+    }
 
-	for(const elem of elems) {
-		const model_id = elem.dataset.model;
-		const revision = elem.dataset.revision;
-        const url = "/api/model/" + model_id + "/" + revision;
-        
-        initTHREE(url);
-	}
-}
+    processModel(gltf) {
+        document.getElementById("model-status").style.display = "none";
+        this.stats = this.calculateModelStats(gltf.scene, gltf.animations);
+        this.updateModelStats(this.stats);
+    }
 
-function initTHREE(fileURL) {
-    const loader = new GLTFLoader();
+    calculateModelStats(model, animations) {
+        let faceCount = 0;
+        let meshCount = 0;
 
-    loader.load(
-        fileURL,
-        function (gltf) {
-            document.getElementById("model-status").style.display = "none";
-            processModel(gltf);
-        },
-        function (progress) {
-            const percent = progress.total > 0
-                ? (progress.loaded / progress.total * 100).toFixed(1)
-                : "0";
-            document.getElementById("model-preview").style.display = "block";
-            document.getElementById("model-status").textContent =
-                `Loading model... ${percent}%`;
-        },
-        function (error) {
-            console.error("Error loading model:", error);
-            document.getElementById("model-status").textContent = "Error loading model: " + error.message;
-            document.getElementById("model-status").style.display = "block";
-            document.getElementById("model-preview").style.display = "none";
-        }
-    );
-}
+        const seenMaterials = new Set();
+        const seenPBRTextures = new Set();
+        const seenOtherTextures = new Set();
+        const boundingBox = new THREE.Box3().setFromObject(model);
 
-function processModel(gltf) {
-    const stats = calculateModelStats(gltf.scene, gltf.animations);
-    updateModelStats(stats);
-}
-
-function calculateModelStats(model, animations) {
-    let faceCount = 0;
-    let meshCount = 0;
-
-    const seenMaterials = new Set();
-    const seenPBRTextures = new Set();
-    const seenOtherTextures = new Set();
-    const boundingBox = new THREE.Box3().setFromObject(model);
-
-    model.traverse(function (child) {
-        if (child.isMesh) {
-            meshCount++;
-        }
-        if (child.isMesh && child.geometry) {
-            if (child.geometry.index) {
-                faceCount += child.geometry.index.count / 3;
-            } else if (child.geometry.attributes.position) {
-                faceCount += child.geometry.attributes.position.count / 3;
+        model.traverse(function (child) {
+            if (child.isMesh) {
+                meshCount++;
             }
-        }
-        if (child.isMesh && child.material){
-            const materials = Array.isArray(child.material)
-                ? child.material
-                : [child.material];
-            materials.forEach((mat) => {
-                seenMaterials.add(mat.uuid);
+            if (child.isMesh && child.geometry) {
+                if (child.geometry.index) {
+                    faceCount += child.geometry.index.count / 3;
+                } else if (child.geometry.attributes.position) {
+                    faceCount += child.geometry.attributes.position.count / 3;
+                }
+            }
+            if (child.isMesh && child.material) {
+                const materials = Array.isArray(child.material)
+                    ? child.material
+                    : [child.material];
+                materials.forEach((mat) => {
+                    seenMaterials.add(mat.uuid);
 
+                    const PBRTextures = [
+                        'metalnessMap',
+                        'roughnessMap',
+                        'normalMap',
+                        'aoMap',
+                        'emissiveMap',
+                        'clearcoatMap',
+                        'clearcoatRoughnessMap',
+                        'clearcoatNormalMap',
+                    ];
+                    const otherTextures = [
+                        'map',
+                        'bumpMap',
+                        'displacementMap',
+                        'alphaMap',
+                        'envMap',
+                        'sheenColorMap',
+                        'specularMap'
+                    ];
+                    const allTextures = [
+                        ...PBRTextures.map(slot => ({ slot, isPBR: true })),
+                        ...otherTextures.map(slot => ({ slot, isPBR: false }))
+                    ];
 
-                const PBRTextures = [
-                    'metalnessMap',
-                    'roughnessMap',
-                    'normalMap',
-                    'aoMap',
-                    'emissiveMap',
-                    'clearcoatMap',
-                    'clearcoatRoughnessMap',
-                    'clearcoatNormalMap',
-                ];
-                const otherTextures = [
-                    'map',
-                    'bumpMap',
-                    'displacementMap',
-                    'alphaMap',
-                    'envMap',
-                    'sheenColorMap',
-                    'specularMap'
-                ];
-                const allTextures = [
-                    ...PBRTextures.map(slot => ({ slot, isPBR: true })),
-                    ...otherTextures.map(slot => ({ slot, isPBR: false }))
-                ];
-
-                allTextures.forEach(({ slot, isPBR }) => {
-                    const tex = mat[slot];
-                    if (tex && tex.isTexture) {
-                        (isPBR ? seenPBRTextures : seenOtherTextures).add(tex.uuid);
-                    }
+                    allTextures.forEach(({ slot, isPBR }) => {
+                        const tex = mat[slot];
+                        if (tex && tex.isTexture) {
+                            (isPBR ? seenPBRTextures : seenOtherTextures).add(tex.uuid);
+                        }
+                    });
                 });
-            });
+            }
+        });
+
+        const size = boundingBox.getSize(new THREE.Vector3());
+
+        const hasAnimations = Array.isArray(animations) && animations.length > 0;
+        const triangleDensity = faceCount / (size.x * size.y * size.z || 1);
+
+        return {
+            faces: Math.floor(faceCount),
+            volume: size.x * size.y * size.z,
+            triangleDensity: triangleDensity.toFixed(2),
+            boundingBox: {
+                width: size.x.toFixed(2),
+                height: size.y.toFixed(2),
+                depth: size.z.toFixed(2)
+            },
+            hasTextures: Boolean(seenPBRTextures.size + seenOtherTextures.size),
+            PBRTextureCount: seenPBRTextures.size,
+            meshes: meshCount,
+            hasAnimations,
+        };
+    }
+
+    setStatQualityClass(id, quality) {
+        const el = document.getElementById(id);
+        if (!el) return;
+
+        const classMap = {
+            good: "text-success",
+            warning: "text-warning",
+            bad: "text-danger",
+            neutral: "text-muted"
+        };
+        el.classList.remove(...Object.values(classMap));
+
+        if (quality && classMap[quality]) {
+            el.classList.add(classMap[quality]);
         }
-    });
+    }
 
-    const size = boundingBox.getSize(new THREE.Vector3());
+    updateModelStats(stats) {
+        const fc = stats.faces;
+        document.getElementById("faceCount").textContent = fc.toLocaleString("en-US");
+        this.setStatQualityClass("faceCount",
+            fc <= 5000 ? "good" :
+                fc <= 100000 ? "warning" : "bad"
+        );
 
-    const hasAnimations = Array.isArray(animations) && animations.length > 0;
-    const triangleDensity = faceCount / (size.x * size.y * size.z || 1);
+        const hasTextures = stats.hasTextures;
+        document.getElementById("hasTextures").textContent = hasTextures ? "Yes" : "No";
+        this.setStatQualityClass("hasTextures",
+            hasTextures ? "good" : "warning"
+        );
 
-    return {
-        faces: Math.floor(faceCount),
-        volume: size.x * size.y * size.z,
-        triangleDensity: triangleDensity.toFixed(2),
+        const PBRTextureCount = stats.PBRTextureCount;
+        document.getElementById("PBRTextureCount").textContent = PBRTextureCount;
+        this.setStatQualityClass("PBRTextureCount",
+            PBRTextureCount ? "good" : "warning"
+        );
 
-        boundingBox: {
-            width: size.x.toFixed(2),
-            height: size.y.toFixed(2),
-            depth: size.z.toFixed(2)
-        },
-        hasTextures: Boolean(seenPBRTextures.size + seenOtherTextures.size),
-        PBRTextureCount: seenPBRTextures.size,
-        meshes: meshCount,
-        hasAnimations,
-    };
-}
+        const mesh = stats.meshes;
+        document.getElementById("meshCount").textContent = mesh.toLocaleString("en-US");
+        this.setStatQualityClass("meshCount", mesh >= 1 ? "good" : "bad");
 
-function setStatQualityClass(id, quality) {
-    const el = document.getElementById(id);
-    if (!el) return;
+        const density = stats.triangleDensity;
+        document.getElementById("triangleDensity").innerHTML = density.toLocaleString("en-US") + " triangles/m<sup>3</sup>";
+        this.setStatQualityClass("triangleDensity",
+            density > 0 && density <= 500 ? "good" :
+                density <= 1000 ? "warning" : "bad"
+        );
 
-    const classMap = {
-        good: "text-success",
-        warning: "text-warning",
-        bad: "text-danger",
-        neutral: "text-muted"
-    };
-    el.classList.remove(...Object.values(classMap));
+        document.getElementById("boundingBox").textContent =
+            `${stats.boundingBox.width}m × ${stats.boundingBox.height}m × ${stats.boundingBox.depth}m`;
+        const volume = stats.volume;
+        this.setStatQualityClass("boundingBox",
+            volume > 0.01 ? "good" :
+                volume > 0.001 ? "warning" : "bad"
+        );
 
-    if (quality && classMap[quality]) {
-        el.classList.add(classMap[quality]);
+        document.getElementById("hasAnimations").textContent = stats.hasAnimations ? "Yes" : "No";
     }
 }
 
-function updateModelStats(stats) {
-    const fc = stats.faces;
-    document.getElementById("faceCount").textContent = fc.toLocaleString("en-US");
-    setStatQualityClass("faceCount", 
-        fc <= 5000 ? "good" :
-        fc <= 100000 ? "warning" : "bad"
-    );
-
-    const hasTextures = stats.hasTextures;
-    document.getElementById("hasTextures").textContent = hasTextures ? "Yes" : "No";
-    setStatQualityClass("hasTextures", 
-        hasTextures ? "good" : "warning"
-    );
-
-    const PBRTextureCount = stats.PBRTextureCount;
-    document.getElementById("PBRTextureCount").textContent = PBRTextureCount;
-    setStatQualityClass("PBRTextureCount", 
-        PBRTextureCount ? "good" : "warning"
-    );
-
-    const mesh = stats.meshes;
-    document.getElementById("meshCount").textContent = mesh.toLocaleString("en-US");
-    setStatQualityClass("meshCount", mesh >= 1 ? "good" : "bad");
-
-    const density = stats.triangleDensity;
-    document.getElementById("triangleDensity").innerHTML = density.toLocaleString("en-US") + " triangles/m<sup>3</sup>";
-    setStatQualityClass("triangleDensity", 
-        density > 0 && density <= 500 ? "good" :
-        density <= 1000 ? "warning" : "bad"
-    );
-
-    document.getElementById("boundingBox").textContent =
-        `${stats.boundingBox.width}m × ${stats.boundingBox.height}m × ${stats.boundingBox.depth}m`;
-    const volume = stats.volume;
-    setStatQualityClass("boundingBox", 
-        volume > 0.01 ? "good" :
-        volume > 0.001 ? "warning" : "bad"
-    );
-
-    document.getElementById("hasAnimations").textContent = stats.hasAnimations ? "Yes" : "No";
-}
-
-window.initStatsTHREE = initTHREE;
-window.setUpStats = setUpStats;
+window.ModelStats = ModelStats;

--- a/mainapp/static_src/src/preview.js
+++ b/mainapp/static_src/src/preview.js
@@ -377,7 +377,7 @@ class ModelPreview {
 	}
 }
 
-function setUpRenderPane(onLoaded) {
+function setUpRenderPane({ onLoaded } = {}) {
 	const elems = document.querySelectorAll('div.render-pane');
 
 	for (const elem of elems) {

--- a/mainapp/static_src/src/preview.js
+++ b/mainapp/static_src/src/preview.js
@@ -2,113 +2,85 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-let axesHelper = null;
-let gridHelper = null;
-let northArrowHelper = null;
-let frontArrowHelper = null;
-let htmlLabels = {};
-let distanceMarkers = {};
-let labelsContainer = null;
-let scaleContainer = null;
-let gridSize = 100;
-let groundPosition = 0;
+class ModelPreview {
+	constructor(elementId, options = {}) {
+		this.axesHelper = null;
+		this.gridHelper = null;
+		this.northArrowHelper = null;
+		this.frontArrowHelper = null;
+		this.htmlLabels = {};
+		this.distanceMarkers = {};
+		this.labelsContainer = null;
+		this.scaleContainer = null;
+		this.gridSize = 100;
+		this.groundPosition = 0;
+		this.mixer = null;
 
-function setUpRenderPane(){
-	const elems = document.querySelectorAll('div.render-pane');
+		this.renderPane = document.getElementById(elementId);
+		this.options = options;
 
-	for(const elem of elems) {
-		const model_id = elem.dataset.model;
-		const revision = elem.dataset.revision;
-		const url = "/api/model/" + model_id + "/" + revision;
+		if (typeof this.options['width'] === 'undefined')
+			this.options['width'] = this.renderPane.clientWidth;
 
-		displayPreview(elem.id, url, {}, model_id, revision,);
+		if (typeof this.options['height'] === 'undefined')
+			this.options['height'] = this.renderPane.clientHeight;
+
+		this.initThreeScene();
 	}
-}
 
-function displayPreview(elementId, url, options={}) {
+	initThreeScene() {
+		this.renderer = new THREE.WebGLRenderer({ antialias: true });
+		this.renderer.setPixelRatio(window.devicePixelRatio);
+		this.renderer.setSize(this.options['width'], this.options['height']);
+		this.renderer.outputEncoding = THREE.sRGBEncoding;
+		this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+		this.renderer.toneMappingExposure = 1.0;
+		this.renderer.physicallyCorrectLights = true;
+		this.renderer.shadowMap.enabled = true;
+		this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-	const three = initTHREE(elementId, options);
-	loadGLB(url, options, three);
-}
+		this.renderPane.appendChild(this.renderer.domElement);
 
-function initTHREE(elementId, options) {
-	const renderPane = document.getElementById(elementId);
+		this.scene = new THREE.Scene();
+		this.scene.background = new THREE.Color(0x87cefa);
 
-	if(typeof options['width'] === 'undefined')
-		options['width'] = renderPane.clientWidth;
+		this.camera = new THREE.PerspectiveCamera(75, this.options['width'] / this.options['height'], 0.1, 1000);
+		this.resizeCanvas();
 
-	if(typeof options['height'] === 'undefined')
-		options['height'] = renderPane.clientHeight;
+		this.controls = new OrbitControls(this.camera, this.renderer.domElement);
 
-	const renderer = new THREE.WebGLRenderer({ antialias: true });
-	renderer.setPixelRatio(window.devicePixelRatio);
-	renderer.setSize(options['width'], options['height']);
-	renderer.outputEncoding = THREE.sRGBEncoding;
-	renderer.toneMapping = THREE.ACESFilmicToneMapping;
-	renderer.toneMappingExposure = 1.0;
-	renderer.physicallyCorrectLights = true;
-	renderer.shadowMap.enabled = true;
-	renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+		const ambLight = new THREE.AmbientLight(0xffffff, 0.4);
+		this.scene.add(ambLight);
 
-	renderPane.appendChild(renderer.domElement);
+		const dirLight = new THREE.DirectionalLight(0xffffff, 1.0);
+		dirLight.position.set(5, 10, 7.5);
+		dirLight.castShadow = true;
+		dirLight.shadow.mapSize.width = 2048;
+		dirLight.shadow.mapSize.height = 2048;
+		dirLight.shadow.bias = -0.0001;
+		this.scene.add(dirLight);
 
-	const scene = new THREE.Scene();
-	scene.background = new THREE.Color(0x87cefa);
+		const hemiLight = new THREE.HemisphereLight(0xffffff, 0x000000, 0.6);
+		this.scene.add(hemiLight);
 
-	const camera = new THREE.PerspectiveCamera(75, options['width'] / options['height'], 0.1, 1000);
-	resizeCanvas(renderer, camera, options);
+		const pointLight = new THREE.PointLight(0xffffff, 1, 100);
+		pointLight.position.set(10, 10, 10);
+		pointLight.castShadow = true;
+		pointLight.shadow.mapSize.width = 2048;
+		pointLight.shadow.mapSize.height = 2048;
+		pointLight.shadow.camera.near = 0.5;
+		pointLight.shadow.camera.far = 500;
+		pointLight.shadow.camera.fov = 50;
+		this.scene.add(pointLight);
 
-	const controls = new OrbitControls(camera, renderer.domElement);
-
-	const ambLight = new THREE.AmbientLight(0xffffff, 0.4);
-	scene.add(ambLight);
-
-	const dirLight = new THREE.DirectionalLight(0xffffff, 1.0);
-	dirLight.position.set(5, 10, 7.5);
-	dirLight.castShadow = true;
-	dirLight.shadow.mapSize.width = 2048;
-	dirLight.shadow.mapSize.height = 2048;
-	dirLight.shadow.bias = -0.0001;
-	scene.add(dirLight);
-
-	const hemiLight = new THREE.HemisphereLight(0xffffff, 0x000000, 0.6);
-	scene.add(hemiLight);
-
-	const pointLight = new THREE.PointLight(0xffffff, 1, 100);
-	pointLight.position.set(10, 10, 10);
-	pointLight.castShadow = true;
-	pointLight.shadow.mapSize.width = 2048;
-	pointLight.shadow.mapSize.height = 2048;
-	pointLight.shadow.camera.near = 0.5;
-	pointLight.shadow.camera.far = 500;
-	pointLight.shadow.camera.fov = 50;
-	scene.add(pointLight);
-
-	renderer.render(scene, camera);
-
-	return {
-		'scene': scene,
-		'camera': camera,
-		'renderer': renderer,
-		'controls': controls,
-		'renderPane': renderPane,
+		this.renderer.render(this.scene, this.camera);
 	}
-}
 
-function loadGLB(url, options, three) {
-	const loader = new GLTFLoader();
-
-	loader.load(url, function(gltf) {
-		const scene = three.scene;
-		const camera = three.camera;
-		const renderer = three.renderer;
-		const controls = three.controls;
-		const renderPane = three.renderPane;
-
+	displayModel(gltf) {
 		const object = gltf.scene;
-		scene.add(object);
+		this.scene.add(object);
 
-		object.traverse(function(child) {
+		object.traverse((child) => {
 			if (child.isMesh) {
 				child.castShadow = true;
 				child.receiveShadow = true;
@@ -118,298 +90,311 @@ function loadGLB(url, options, three) {
 		const bbox = new THREE.Box3().setFromObject(object);
 		const center = bbox.getCenter(new THREE.Vector3());
 		const size = bbox.getSize(new THREE.Vector3());
-		groundPosition = -size.y/2 - bbox.min.y;
+		this.groundPosition = -size.y / 2 - bbox.min.y;
 
 		object.position.sub(center);
 
 		const maxDim = Math.max(size.x, size.y, size.z);
-		const fov = camera.fov * (Math.PI / 180);
+		const fov = this.camera.fov * (Math.PI / 180);
 		const cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
-		camera.position.set(center.x, center.y, cameraZ * 1.5);
-		camera.lookAt(new THREE.Vector3(0, 0, 0));
+		this.camera.position.set(center.x, center.y, cameraZ * 1.5);
+		this.camera.lookAt(new THREE.Vector3(0, 0, 0));
 
 		if (maxDim >= 5)
-			gridSize = Math.ceil(maxDim / 50) * 50;
+			this.gridSize = Math.ceil(maxDim / 50) * 50;
 		else
-			gridSize = maxDim;
+			this.gridSize = maxDim;
 
-		let mixer = null;
-	
 		if (gltf.animations && gltf.animations.length > 0) {
-			mixer = new THREE.AnimationMixer(object);
+			this.mixer = new THREE.AnimationMixer(object);
 			gltf.animations.forEach((clip) => {
-				mixer.clipAction(clip).play();
+				this.mixer.clipAction(clip).play();
 			});
 		}
 
-		setupFullscreenButton(three);
-
-		animate(renderer, scene, camera, controls, options, mixer, renderPane);
-	}, undefined, function(error) {
-		console.error("Error loading GLB:", error);
-	});
-}
-
-function animate(renderer, scene, camera, controls, options, mixer, renderPane) {
-	// clock instance needs to be outside the animation
-	// loop to ensure consistency with the mixer 
-	const clock = new THREE.Clock();
-
-	function loop() {
-		requestAnimationFrame(loop);
-
-		const delta = clock.getDelta();
-
-		if (mixer) mixer.update(delta);
-
-		resizeCanvas(renderer, camera, options, renderPane);
-
-		controls.update();
-
-		if (document.fullscreenElement) {
-			updateLabels(camera);
-		}
-
-		renderer.render(scene, camera);
+		this.setupFullscreenButton();
+		this.animate();
 	}
 
-	loop();
-}
+	loadAndDisplay(url, onLoaded) {
+		const loader = new GLTFLoader();
 
-
-function resizeCanvas(renderer, camera, options, renderPane) {
-	const canvas = renderer.domElement;
-
-	canvas.style = null;
-	let width, height;
-	if (document.fullscreenElement === renderPane) {
-		width = window.innerWidth; 
-		height = window.innerHeight;
-	} else {
-		width = options['width'];
-		height = options['height'];
+		loader.load(url, (gltf) => {
+			this.displayModel(gltf);
+			if (onLoaded) onLoaded(gltf);
+		}, undefined, (error) => {
+			console.error("Error loading GLB:", error);
+		});
 	}
 
-	if(canvas.width != width || canvas.height != height) {
-		renderer.setSize(width, height, false);
-		camera.aspect = width/height;
-		camera.updateProjectionMatrix();
+	animate() {
+		const clock = new THREE.Clock();
+
+		const loop = () => {
+			requestAnimationFrame(loop);
+
+			const delta = clock.getDelta();
+
+			if (this.mixer) this.mixer.update(delta);
+
+			this.resizeCanvas();
+
+			this.controls.update();
+
+			if (document.fullscreenElement) {
+				this.updateLabels();
+			}
+
+			this.renderer.render(this.scene, this.camera);
+		};
+
+		loop();
 	}
-}
 
-function toggleVisualHelpers(scene, enable) {
-	if (enable) {
-		if (!axesHelper) {
-			axesHelper = new THREE.AxesHelper(gridSize/2);
-			axesHelper.position.y = groundPosition;
-			scene.add(axesHelper);
+	resizeCanvas() {
+		const canvas = this.renderer.domElement;
+
+		canvas.style = null;
+		let width, height;
+		if (document.fullscreenElement === this.renderPane) {
+			width = window.innerWidth;
+			height = window.innerHeight;
+		} else {
+			width = this.options['width'];
+			height = this.options['height'];
 		}
 
-		if (!gridHelper) {
-			gridHelper = new THREE.GridHelper(gridSize);
-			gridHelper.position.y = groundPosition;
-			scene.add(gridHelper);
+		if (canvas.width != width || canvas.height != height) {
+			this.renderer.setSize(width, height, false);
+			this.camera.aspect = width / height;
+			this.camera.updateProjectionMatrix();
+		}
+	}
+
+	toggleVisualHelpers(enable) {
+		if (enable) {
+			if (!this.axesHelper) {
+				this.axesHelper = new THREE.AxesHelper(this.gridSize / 2);
+				this.axesHelper.position.y = this.groundPosition;
+				this.scene.add(this.axesHelper);
+			}
+
+			if (!this.gridHelper) {
+				this.gridHelper = new THREE.GridHelper(this.gridSize);
+				this.gridHelper.position.y = this.groundPosition;
+				this.scene.add(this.gridHelper);
+			}
+
+			const z_dir = new THREE.Vector3(0, 0, 1);
+			const neg_z_dir = new THREE.Vector3(0, 0, -1);
+			const origin = new THREE.Vector3(0, this.groundPosition, 0);
+			const length = this.gridSize * 1.1 / 2;
+			const gridSpacing = this.gridSize / 10;
+
+			if (!this.northArrowHelper) {
+				this.northArrowHelper = new THREE.ArrowHelper(neg_z_dir, origin, length, 0xFFD700, gridSpacing * 0.3, 0.1 * gridSpacing);
+				this.scene.add(this.northArrowHelper);
+			}
+			if (!this.frontArrowHelper) {
+				this.frontArrowHelper = new THREE.ArrowHelper(z_dir, origin, length, 0x0000FF, gridSpacing * 0.3, 0.1 * gridSpacing);
+				this.scene.add(this.frontArrowHelper);
+			}
+
+			this.labelsContainer = document.getElementById('labels-container');
+			if (this.labelsContainer) {
+				this.labelsContainer.style.display = 'block';
+				if (Object.keys(this.htmlLabels).length === 0) {
+					this.labelsContainer = document.getElementById('labels-container');
+					if (!this.labelsContainer) return;
+
+					this.labelsContainer.innerHTML = '';
+					this.htmlLabels = {};
+
+					this.htmlLabels.x = this.createLabelElement('X', 'red');
+					this.htmlLabels.y = this.createLabelElement('Y', 'green');
+					this.htmlLabels.z = this.createLabelElement('Z', 'blue');
+					this.htmlLabels.front = this.createLabelElement('Front', 'blue');
+					this.htmlLabels.north = this.createLabelElement('North', 'yellow');
+					this.labelsContainer.appendChild(this.htmlLabels.x);
+					this.labelsContainer.appendChild(this.htmlLabels.y);
+					this.labelsContainer.appendChild(this.htmlLabels.z);
+					this.labelsContainer.appendChild(this.htmlLabels.front);
+					this.labelsContainer.appendChild(this.htmlLabels.north);
+
+					this.distanceMarkers = {};
+
+					for (let i = -5; i <= 5; i++) {
+						const distance = i * gridSpacing;
+						this.distanceMarkers[`marker_x_${i}`] = this.createLabelElement(`${distance.toFixed(1)}`, 'skyblue');
+						this.labelsContainer.appendChild(this.distanceMarkers[`marker_x_${i}`]);
+						this.distanceMarkers[`marker_z_${i}`] = this.createLabelElement(`${distance.toFixed(1)}`, 'skyblue');
+						this.labelsContainer.appendChild(this.distanceMarkers[`marker_z_${i}`]);
+					}
+				}
+			}
+
+			this.scaleContainer = document.getElementById('scale-container');
+			if (this.scaleContainer) {
+				this.scaleContainer.style.display = 'block';
+				if (!this.gridSize) return;
+
+				const gridSpacingEl = document.getElementById('grid-spacing-value');
+				if (gridSpacingEl) gridSpacingEl.textContent = `${gridSpacing.toFixed(1)}m`;
+			}
+		} else {
+			if (this.axesHelper) {
+				this.scene.remove(this.axesHelper);
+				this.axesHelper.dispose();
+				this.axesHelper = null;
+			}
+
+			if (this.gridHelper) {
+				this.scene.remove(this.gridHelper);
+				this.gridHelper.dispose();
+				this.gridHelper = null;
+			}
+
+			if (this.northArrowHelper) {
+				this.scene.remove(this.northArrowHelper);
+				this.northArrowHelper.dispose();
+				this.northArrowHelper = null;
+			}
+			if (this.frontArrowHelper) {
+				this.scene.remove(this.frontArrowHelper);
+				this.frontArrowHelper.dispose();
+				this.frontArrowHelper = null;
+			}
+
+			if (this.labelsContainer) {
+				this.labelsContainer.style.display = 'none';
+			}
+
+			if (this.scaleContainer) {
+				this.scaleContainer.style.display = 'none';
+			}
+		}
+	}
+
+	createLabelElement(text, color) {
+		const div = document.createElement('div');
+		div.className = 'axis-label';
+		div.style.color = color;
+		div.textContent = text;
+		return div;
+	}
+
+	updateLabels() {
+		if (!this.labelsContainer || this.labelsContainer.style.display === 'none' || !this.camera) return;
+
+		const tempV = new THREE.Vector3();
+		const label3DPositions = {
+			x: new THREE.Vector3(this.gridSize / 2, this.groundPosition, 0),
+			y: new THREE.Vector3(0, this.gridSize / 2 + this.groundPosition, 0),
+			z: new THREE.Vector3(0, this.groundPosition, this.gridSize / 2),
+			north: new THREE.Vector3(0, this.groundPosition, -this.gridSize * 1.11 / 2),
+			front: new THREE.Vector3(0, this.groundPosition, this.gridSize * 1.11 / 2),
+		};
+
+		for (const labelItem in { x: true, y: true, z: true, north: true, front: true }) {
+			const label = this.htmlLabels[labelItem];
+			const position = label3DPositions[labelItem];
+
+			tempV.copy(position);
+			tempV.project(this.camera);
+
+			const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
+			const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
+
+			label.style.left = `${x}px`;
+			label.style.top = `${y}px`;
 		}
 
-		const z_dir = new THREE.Vector3(0, 0, 1);
-		const neg_z_dir = new THREE.Vector3(0, 0, -1);
-		const origin = new THREE.Vector3(0, groundPosition, 0);
-		// slightly offset to avoid overlap with the grid
-		const length = gridSize * 1.1 / 2;
-		const gridSpacing = gridSize / 10;
+		if (Object.keys(this.distanceMarkers).length > 0) {
+			const gridSpacing = this.gridSize / 10;
 
-		if (!northArrowHelper) {
-			northArrowHelper = new THREE.ArrowHelper(neg_z_dir, origin, length, 0xFFD700, gridSpacing * 0.3, 0.1 * gridSpacing);
-			scene.add(northArrowHelper);
-		}
-		if (!frontArrowHelper) {
-			frontArrowHelper = new THREE.ArrowHelper(z_dir, origin, length, 0x0000FF, gridSpacing * 0.3, 0.1 * gridSpacing);
-			scene.add(frontArrowHelper);
-		}
+			for (let i = -5; i <= 5; i++) {
+				const marker_x = this.distanceMarkers[`marker_x_${i}`];
+				const marker_z = this.distanceMarkers[`marker_z_${i}`];
+				if (marker_x) {
+					const markerPositionX = new THREE.Vector3(
+						-this.gridSize / 2,
+						this.groundPosition,
+						(i * gridSpacing),
+					);
 
-		labelsContainer = document.getElementById('labels-container');
-		if (labelsContainer) {
-			labelsContainer.style.display = 'block';
-			if (Object.keys(htmlLabels).length === 0) {
-				labelsContainer = document.getElementById('labels-container');
-				if (!labelsContainer) return;
+					tempV.copy(markerPositionX);
+					tempV.project(this.camera);
+					const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
+					const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
+					marker_x.style.left = `${x}px`;
+					marker_x.style.top = `${y}px`;
+				}
+				if (marker_z) {
+					const markerPositionZ = new THREE.Vector3(
+						(i * gridSpacing),
+						this.groundPosition,
+						-this.gridSize / 2
+					);
 
-				labelsContainer.innerHTML = '';
-				htmlLabels = {};
-
-				htmlLabels.x = createLabelElement('X', 'red');
-				htmlLabels.y = createLabelElement('Y', 'green');
-				htmlLabels.z = createLabelElement('Z', 'blue');
-				htmlLabels.front = createLabelElement('Front', 'blue');
-				htmlLabels.north = createLabelElement('North', 'yellow');
-				labelsContainer.appendChild(htmlLabels.x);
-				labelsContainer.appendChild(htmlLabels.y);
-				labelsContainer.appendChild(htmlLabels.z);
-				labelsContainer.appendChild(htmlLabels.front);
-				labelsContainer.appendChild(htmlLabels.north);
-
-				distanceMarkers = {};
-				
-				for (let i = -5; i <= 5; i++) {
-					const distance = i * gridSpacing;
-					distanceMarkers[`marker_x_${i}`] = createLabelElement(`${distance.toFixed(1)}`, 'skyblue');
-					labelsContainer.appendChild(distanceMarkers[`marker_x_${i}`]);
-					distanceMarkers[`marker_z_${i}`] = createLabelElement(`${distance.toFixed(1)}`, 'skyblue');
-					labelsContainer.appendChild(distanceMarkers[`marker_z_${i}`]);
+					tempV.copy(markerPositionZ);
+					tempV.project(this.camera);
+					const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
+					const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
+					marker_z.style.left = `${x}px`;
+					marker_z.style.top = `${y}px`;
 				}
 			}
 		}
-
-		scaleContainer = document.getElementById('scale-container');
-		if (scaleContainer) {
-			scaleContainer.style.display = 'block';
-			if (!gridSize) return;
-
-			const gridSpacingEl = document.getElementById('grid-spacing-value');
-			if (gridSpacingEl) gridSpacingEl.textContent = `${gridSpacing.toFixed(1)}m`;
-		}
-	} else {
-		if (axesHelper) {
-			scene.remove(axesHelper);
-			axesHelper.dispose();
-			axesHelper = null;
-		}
-
-		if (gridHelper) {
-			scene.remove(gridHelper);
-			gridHelper.dispose();
-			gridHelper = null;
-		}
-
-		if (northArrowHelper) {
-			scene.remove(northArrowHelper);
-			northArrowHelper.dispose();
-			northArrowHelper = null;
-		}
-		if (frontArrowHelper) {
-			scene.remove(frontArrowHelper);
-			frontArrowHelper.dispose();
-			frontArrowHelper = null;
-		}
-
-		if (labelsContainer) {
-			labelsContainer.style.display = 'none';
-		}
-
-		if (scaleContainer) {
-			scaleContainer.style.display = 'none';
-		}
-	}
-}
-
-function createLabelElement(text, color) {
-	const div = document.createElement('div');
-	div.className = 'axis-label';
-	div.style.color = color;
-	div.textContent = text;
-	return div;
-}
-
-function updateLabels(camera) {
-	if (!labelsContainer || labelsContainer.style.display === 'none' || !camera) return;
-
-	const tempV = new THREE.Vector3();
-	const label3DPositions = {
-		x: new THREE.Vector3(gridSize/2, groundPosition, 0),
-		y: new THREE.Vector3(0, gridSize/2 + groundPosition, 0),
-		z: new THREE.Vector3(0, groundPosition, gridSize/2),
-		// slightly offset to avoid overlap with the arrow head
-		north: new THREE.Vector3(0, groundPosition, -gridSize * 1.11 / 2),
-		front: new THREE.Vector3(0, groundPosition, gridSize * 1.11 / 2),
-	};
-
-	for (const labelItem in {x:true, y:true, z:true, north:true, front:true}) {
-		const label = htmlLabels[labelItem];
-		const position = label3DPositions[labelItem];
-
-		tempV.copy(position);
-		tempV.project(camera);
-
-		const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
-		const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
-
-		label.style.left = `${x}px`;
-		label.style.top = `${y}px`;
 	}
 
-	if (Object.keys(distanceMarkers).length > 0) {
-		const gridSpacing = gridSize / 10;
-		
-		for (let i = -5; i <= 5; i++) {
-			const marker_x = distanceMarkers[`marker_x_${i}`];
-			const marker_z = distanceMarkers[`marker_z_${i}`];
-			if (marker_x) {
-				
-				const markerPositionX = new THREE.Vector3(
-					-gridSize/2,
-					groundPosition, 
-					(i * gridSpacing), 
-				);
-				
-				tempV.copy(markerPositionX);
-				tempV.project(camera);
-				const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
-				const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
-				marker_x.style.left = `${x}px`;
-				marker_x.style.top = `${y}px`;
+	handleFullscreenChange() {
+		const isFullscreen = document.fullscreenElement === this.renderPane;
+
+		if (isFullscreen) {
+			this.toggleVisualHelpers(true);
+		} else {
+			this.toggleVisualHelpers(false);
+		}
+
+		this.resizeCanvas();
+	}
+
+	setupFullscreenButton() {
+		const fullscreenButton = document.getElementById('fullscreen-button');
+		if (!fullscreenButton) return;
+
+		fullscreenButton.addEventListener('click', () => {
+			if (!document.fullscreenElement && this.renderPane.requestFullscreen) {
+				this.renderPane.requestFullscreen();
+			} else if (document.exitFullscreen) {
+				document.exitFullscreen();
 			}
-			if (marker_z) {
-				const markerPositionZ = new THREE.Vector3(
-					(i * gridSpacing), 
-					groundPosition, 
-					-gridSize/2
-				);
+		});
 
-				tempV.copy(markerPositionZ);
-				tempV.project(camera);
-				const x = (tempV.x * 0.5 + 0.5) * window.innerWidth;
-				const y = (-tempV.y * 0.5 + 0.5) * window.innerHeight;
-				marker_z.style.left = `${x}px`;
-				marker_z.style.top = `${y}px`;
-
-			}
-		}
+		document.addEventListener('fullscreenchange', () => {
+			this.handleFullscreenChange();
+		});
 	}
 }
 
-function handleFullscreenChange(threeInstance) {
-	const renderPane = document.querySelector('.render-pane');
-	const isFullscreen = document.fullscreenElement === renderPane;
+function setUpRenderPane(onLoaded) {
+	const elems = document.querySelectorAll('div.render-pane');
 
-	if (isFullscreen) {
-		console.log('Entered fullscreen for render-pane');
-		toggleVisualHelpers(threeInstance.scene, true);
-	} else {
-		console.log('Exited fullscreen for render-pane');
-		toggleVisualHelpers(threeInstance.scene, false);
+	for (const elem of elems) {
+		const model_id = elem.dataset.model;
+		const revision = elem.dataset.revision;
+		const url = "/api/model/" + model_id + "/" + revision;
+
+		const preview = new ModelPreview(elem.id);
+		preview.loadAndDisplay(url, onLoaded);
 	}
-	
-	resizeCanvas(threeInstance.renderer, threeInstance.camera, {}, renderPane);
 }
 
-function setupFullscreenButton(threeInstance) {
-	const fullscreenButton = document.getElementById('fullscreen-button');
-	if (!fullscreenButton) return;
-
-	fullscreenButton.addEventListener('click', function (event) {
-		const renderPane = document.querySelector('.render-pane');
-
-		if (!document.fullscreenElement && renderPane.requestFullscreen) {
-			renderPane.requestFullscreen();
-		} else if (document.exitFullscreen) {
-			document.exitFullscreen();
-		}
-	});
-
-	document.addEventListener('fullscreenchange', function (event) {
-		handleFullscreenChange(threeInstance);
-	});
+function displayPreview(elementId, url, options = {}, onLoaded) {
+	const preview = new ModelPreview(elementId, options);
+	preview.loadAndDisplay(url, onLoaded);
 }
 
+window.ModelPreview = ModelPreview;
 window.setUpRenderPane = setUpRenderPane;
 window.displayPreview = displayPreview;

--- a/mainapp/static_src/src/preview.js
+++ b/mainapp/static_src/src/preview.js
@@ -376,22 +376,5 @@ export class ModelPreview {
 		});
 	}
 }
-
-export function setUpRenderPane({ onLoaded } = {}) {
-	const elems = document.querySelectorAll('div.render-pane');
-
-	for (const elem of elems) {
-		const model_id = elem.dataset.model;
-		const revision = elem.dataset.revision;
-		const url = "/api/model/" + model_id + "/" + revision;
-
-		const preview = new ModelPreview(elem.id);
-		preview.loadAndDisplay(url, onLoaded);
-	}
-}
-
-export function displayPreview(elementId, url, options = {}, onLoaded) {
-	const preview = new ModelPreview(elementId, options);
-	preview.loadAndDisplay(url, onLoaded);
-}
+window.ModelPreview = ModelPreview;
 

--- a/mainapp/static_src/src/preview.js
+++ b/mainapp/static_src/src/preview.js
@@ -396,5 +396,3 @@ function displayPreview(elementId, url, options = {}, onLoaded) {
 }
 
 window.ModelPreview = ModelPreview;
-window.setUpRenderPane = setUpRenderPane;
-window.displayPreview = displayPreview;

--- a/mainapp/static_src/src/preview.js
+++ b/mainapp/static_src/src/preview.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
-class ModelPreview {
+export class ModelPreview {
 	constructor(elementId, options = {}) {
 		this.axesHelper = null;
 		this.gridHelper = null;
@@ -377,7 +377,7 @@ class ModelPreview {
 	}
 }
 
-function setUpRenderPane({ onLoaded } = {}) {
+export function setUpRenderPane({ onLoaded } = {}) {
 	const elems = document.querySelectorAll('div.render-pane');
 
 	for (const elem of elems) {
@@ -390,9 +390,8 @@ function setUpRenderPane({ onLoaded } = {}) {
 	}
 }
 
-function displayPreview(elementId, url, options = {}, onLoaded) {
+export function displayPreview(elementId, url, options = {}, onLoaded) {
 	const preview = new ModelPreview(elementId, options);
 	preview.loadAndDisplay(url, onLoaded);
 }
 
-window.ModelPreview = ModelPreview;

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -20,7 +20,7 @@
 	{% if models %}
 	<div class="row flex">
 		{% for model in models %}
-			{% include "mainapp/modelpanel.html" %}
+		{% include "mainapp/modelpanel.html" %}
 		{% endfor %}
 	</div>
 	{% endif %}
@@ -44,8 +44,16 @@
 {% block footeradditions %}
 {% vite_asset 'src/main.js' %}
 <script>
-	window.addEventListener("load", function() {
-		setUpRenderPane();
+	window.addEventListener("load", function () {
+		const elems = document.querySelectorAll('div.render-pane');
+		for (const elem of elems) {
+			const model_id = elem.dataset.model;
+			const revision = elem.dataset.revision;
+			const url = "/api/model/" + model_id + "/" + revision;
+
+			const preview = new ModelPreview(elem.id);
+			preview.loadAndDisplay(url);
+		}
 	});
 </script>
 {% endblock %}

--- a/mainapp/templates/mainapp/index.html
+++ b/mainapp/templates/mainapp/index.html
@@ -20,7 +20,7 @@
 	{% if models %}
 	<div class="row flex">
 		{% for model in models %}
-		{% include "mainapp/modelpanel.html" %}
+			{% include "mainapp/modelpanel.html" %}
 		{% endfor %}
 	</div>
 	{% endif %}
@@ -44,16 +44,16 @@
 {% block footeradditions %}
 {% vite_asset 'src/main.js' %}
 <script>
-	window.addEventListener("load", function () {
+	window.addEventListener("load", function() {
 		const elems = document.querySelectorAll('div.render-pane');
-		for (const elem of elems) {
-			const model_id = elem.dataset.model;
-			const revision = elem.dataset.revision;
-			const url = "/api/model/" + model_id + "/" + revision;
-
-			const preview = new ModelPreview(elem.id);
-			preview.loadAndDisplay(url);
-		}
+ 		for (const elem of elems) {
+ 			const model_id = elem.dataset.model;
+ 			const revision = elem.dataset.revision;
+ 			const url = "/api/model/" + model_id + "/" + revision;
+ 
+ 			const preview = new ModelPreview(elem.id);
+ 			preview.loadAndDisplay(url);
+ 		}
 	});
 </script>
 {% endblock %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -10,7 +10,6 @@
 		width: 750px;
 		height: 480px;
 	}
-
 	.render-pane {
 		min-height: 480px;
 	}
@@ -32,8 +31,7 @@
 		<br>
 		<div class="col-md-12">
 			<ul class="nav nav-tabs" role="tablist">
-				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D
-						View</a></li>
+				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D View</a></li>
 				{% if model.location %}
 				<li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#map" role="tab">Map</a></li>
 				{% endif %}
@@ -44,8 +42,7 @@
 			<div id="model-preview">
 				<div class="tab-content" style="overflow: hidden;">
 					<div class="tab-pane active" id="view" role="tabpanel">
-						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}"
-							id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
+						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}" id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
@@ -84,12 +81,9 @@
 						</div>
 						<div class="panel-body" style="padding:0px;">
 							<ul class="nav nav-tabs" role="tablist">
-								<li role="presentation" class="active"><a href="#overview" aria-controls="overview"
-										role="tab" data-toggle="tab">Overview</a></li>
-								<li role="presentation"><a href="#stats" aria-controls="stats" role="tab"
-										data-toggle="tab">Stats</a></li>
-								<li role="presentation"><a href="#history" aria-controls="history" role="tab"
-										data-toggle="tab">History</a></li>
+								<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
+								<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
+								<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
 							</ul>
 							<div class="tab-content">
 								<div role="tabpanel" class="tab-pane active" id="overview">
@@ -117,9 +111,11 @@
 		{% vite_asset 'src/main.js' %}
 		<script>
 			window.addEventListener("load", function () {
-				setUpRenderPane(function (gltf) {
-					const stats = new ModelStats();
-					stats.processModel(gltf);
+				setUpRenderPane({
+					onLoaded: function (gltf) {
+						const stats = new ModelStats();
+						stats.processModel(gltf);
+					}
 				});
 			});
 

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -46,7 +46,7 @@
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
-								<span>Grid Spacing:</span>
+								<span>Grid Spacing:</span> 
 								<span id="grid-spacing-value">-</span>
 							</div>
 						</div>
@@ -61,66 +61,65 @@
 			</div>
 		</div>
 		<div>
-			<div class="col-md-4">
-				{% if model.is_hidden %}
-				<div class="panel panel-danger">
-					{% else %}
-					<div class="panel panel-primary">
+		<div class="col-md-4">
+			{% if model.is_hidden %}
+			<div class="panel panel-danger">
+			{% else %}
+			<div class="panel panel-primary">
+			{% endif %}
+				<div class="panel-heading">
+					<h3 class="panel-title">
+						{{ model.title }} 
+						{% if not latest_page %}
+							<small style="cursor:help;" title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
+							(Revision {{ model.revision }})
+							</small>
 						{% endif %}
-						<div class="panel-heading">
-							<h3 class="panel-title">
-								{{ model.title }}
-								{% if not latest_page %}
-								<small style="cursor:help;"
-									title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
-									(Revision {{ model.revision }})
-								</small>
-								{% endif %}
-
-							</h3>
-						</div>
-						<div class="panel-body" style="padding:0px;">
-							<ul class="nav nav-tabs" role="tablist">
-								<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
-								<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
-								<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
-							</ul>
-							<div class="tab-content">
-								<div role="tabpanel" class="tab-pane active" id="overview">
-									{% include 'mainapp/model_overview.html' %}
-								</div>
-								<div role="tabpanel" class="tab-pane" id="stats">
-									{% include 'mainapp/model_stats.html' %}
-								</div>
-								<div role="tabpanel" class="tab-pane" id="history">
-									{% include 'mainapp/model_history.html' %}
-								</div>
+						
+					</h3>
+				</div>
+					<div class="panel-body" style="padding:0px;">
+						<ul class="nav nav-tabs" role="tablist">
+							<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
+							<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
+							<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
+						</ul>
+						<div class="tab-content">
+							<div role="tabpanel" class="tab-pane active" id="overview">
+								{% include 'mainapp/model_overview.html' %}
+							</div>
+							<div role="tabpanel" class="tab-pane" id="stats">
+								{% include 'mainapp/model_stats.html' %}
+							</div>
+							<div role="tabpanel" class="tab-pane" id="history">
+								{% include 'mainapp/model_history.html' %}
 							</div>
 						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-		<script>
-			{% if model.location %}
-			initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
-			{% endif %}
-		</script>
-		{% endblock %}
-		{% block footeradditions %}
-		{% vite_asset 'src/main.js' %}
-		<script>
-			window.addEventListener("load", function () {
-				setUpRenderPane({
-					onLoaded: function (gltf) {
-						const stats = new ModelStats();
-						stats.processModel(gltf);
-					}
-				});
-			});
+	</div>
+</div>
+<script>
+{% if model.location %}
+initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
+{% endif %}
+</script>
+{% endblock %}
+{% block footeradditions %}
+{% vite_asset 'src/main.js' %}
+<script>
+	window.addEventListener("load", function () {
+		setUpRenderPane({
+			onLoaded: function (gltf) {
+				const stats = new ModelStats();
+				stats.processModel(gltf);
+			}
+		});
+	});
 
-			confirmDeleteModel = function () {
-				return confirm("Are you sure you want to delete this model? This action cannot be undone.");
-			};
-		</script>
-		{% endblock %}
+	confirmDeleteModel = function() {
+		return confirm("Are you sure you want to delete this model? This action cannot be undone.");
+	};
+</script>
+{% endblock %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -10,6 +10,7 @@
 		width: 750px;
 		height: 480px;
 	}
+
 	.render-pane {
 		min-height: 480px;
 	}
@@ -31,7 +32,8 @@
 		<br>
 		<div class="col-md-12">
 			<ul class="nav nav-tabs" role="tablist">
-				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D View</a></li>
+				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D
+						View</a></li>
 				{% if model.location %}
 				<li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#map" role="tab">Map</a></li>
 				{% endif %}
@@ -42,7 +44,8 @@
 			<div id="model-preview">
 				<div class="tab-content" style="overflow: hidden;">
 					<div class="tab-pane active" id="view" role="tabpanel">
-						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}" id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
+						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}"
+							id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
@@ -71,7 +74,8 @@
 							<h3 class="panel-title">
 								{{ model.title }}
 								{% if not latest_page %}
-							<small style="cursor:help;" title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
+								<small style="cursor:help;"
+									title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
 									(Revision {{ model.revision }})
 								</small>
 								{% endif %}
@@ -80,9 +84,12 @@
 						</div>
 						<div class="panel-body" style="padding:0px;">
 							<ul class="nav nav-tabs" role="tablist">
-							<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
-							<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
-							<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
+								<li role="presentation" class="active"><a href="#overview" aria-controls="overview"
+										role="tab" data-toggle="tab">Overview</a></li>
+								<li role="presentation"><a href="#stats" aria-controls="stats" role="tab"
+										data-toggle="tab">Stats</a></li>
+								<li role="presentation"><a href="#history" aria-controls="history" role="tab"
+										data-toggle="tab">History</a></li>
 							</ul>
 							<div class="tab-content">
 								<div role="tabpanel" class="tab-pane active" id="overview">
@@ -115,7 +122,6 @@
 					const model_id = elem.dataset.model;
 					const revision = elem.dataset.revision;
 					const url = "/api/model/" + model_id + "/" + revision;
-
 					const preview = new ModelPreview(elem.id);
 					preview.loadAndDisplay(url, function (gltf) {
 						const stats = new ModelStats();

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -46,7 +46,7 @@
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
-								<span>Grid Spacing:</span> 
+								<span>Grid Spacing:</span>
 								<span id="grid-spacing-value">-</span>
 							</div>
 						</div>
@@ -61,65 +61,71 @@
 			</div>
 		</div>
 		<div>
-		<div class="col-md-4">
-			{% if model.is_hidden %}
-			<div class="panel panel-danger">
-			{% else %}
-			<div class="panel panel-primary">
-			{% endif %}
-				<div class="panel-heading">
-					<h3 class="panel-title">
-						{{ model.title }} 
-						{% if not latest_page %}
-							<small style="cursor:help;" title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
-							(Revision {{ model.revision }})
-							</small>
+			<div class="col-md-4">
+				{% if model.is_hidden %}
+				<div class="panel panel-danger">
+					{% else %}
+					<div class="panel panel-primary">
 						{% endif %}
-						
-					</h3>
-				</div>
-					<div class="panel-body" style="padding:0px;">
-						<ul class="nav nav-tabs" role="tablist">
+						<div class="panel-heading">
+							<h3 class="panel-title">
+								{{ model.title }}
+								{% if not latest_page %}
+							<small style="cursor:help;" title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
+									(Revision {{ model.revision }})
+								</small>
+								{% endif %}
+
+							</h3>
+						</div>
+						<div class="panel-body" style="padding:0px;">
+							<ul class="nav nav-tabs" role="tablist">
 							<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
 							<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
 							<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
-						</ul>
-						<div class="tab-content">
-							<div role="tabpanel" class="tab-pane active" id="overview">
-								{% include 'mainapp/model_overview.html' %}
-							</div>
-							<div role="tabpanel" class="tab-pane" id="stats">
-								{% include 'mainapp/model_stats.html' %}
-							</div>
-							<div role="tabpanel" class="tab-pane" id="history">
-								{% include 'mainapp/model_history.html' %}
+							</ul>
+							<div class="tab-content">
+								<div role="tabpanel" class="tab-pane active" id="overview">
+									{% include 'mainapp/model_overview.html' %}
+								</div>
+								<div role="tabpanel" class="tab-pane" id="stats">
+									{% include 'mainapp/model_stats.html' %}
+								</div>
+								<div role="tabpanel" class="tab-pane" id="history">
+									{% include 'mainapp/model_history.html' %}
+								</div>
 							</div>
 						</div>
 					</div>
 				</div>
 			</div>
-	</div>
-</div>
-<script>
-{% if model.location %}
-initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
-{% endif %}
-</script>
-{% endblock %}
-{% block footeradditions %}
-{% vite_asset 'src/main.js' %}
-<script>
-	window.addEventListener("load", function () {
-		setUpRenderPane({
-			onLoaded: function (gltf) {
-				const stats = new ModelStats();
-				stats.processModel(gltf);
-			}
-		});
-	});
+		</div>
+		<script>
+			{% if model.location %}
+			initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
+			{% endif %}
+		</script>
+		{% endblock %}
+		{% block footeradditions %}
+		{% vite_asset 'src/main.js' %}
+		<script>
+			window.addEventListener("load", function () {
+				const elems = document.querySelectorAll('div.render-pane');
+				for (const elem of elems) {
+					const model_id = elem.dataset.model;
+					const revision = elem.dataset.revision;
+					const url = "/api/model/" + model_id + "/" + revision;
 
-	confirmDeleteModel = function() {
-		return confirm("Are you sure you want to delete this model? This action cannot be undone.");
-	};
-</script>
-{% endblock %}
+					const preview = new ModelPreview(elem.id);
+					preview.loadAndDisplay(url, function (gltf) {
+						const stats = new ModelStats();
+						stats.processModel(gltf);
+					});
+				}
+			});
+
+			confirmDeleteModel = function () {
+				return confirm("Are you sure you want to delete this model? This action cannot be undone.");
+			};
+		</script>
+		{% endblock %}

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -10,6 +10,7 @@
 		width: 750px;
 		height: 480px;
 	}
+
 	.render-pane {
 		min-height: 480px;
 	}
@@ -31,7 +32,8 @@
 		<br>
 		<div class="col-md-12">
 			<ul class="nav nav-tabs" role="tablist">
-				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D View</a></li>
+				<li class="nav-item active"><a class="nav-link active" data-toggle="tab" href="#view" role="tab">3D
+						View</a></li>
 				{% if model.location %}
 				<li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#map" role="tab">Map</a></li>
 				{% endif %}
@@ -42,11 +44,12 @@
 			<div id="model-preview">
 				<div class="tab-content" style="overflow: hidden;">
 					<div class="tab-pane active" id="view" role="tabpanel">
-						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}" id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
+						<div class="render-pane" data-model="{{ model.model_id }}" data-revision="{{ model.revision }}"
+							id="render-pane{{ model.model_id }}.{{ model.revision }}" style="height: 480px;">
 							<div id="fullscreen-button">&#x26F6;</div>
 							<div id="labels-container"></div>
 							<div id="scale-container" style="display: none;">
-								<span>Grid Spacing:</span> 
+								<span>Grid Spacing:</span>
 								<span id="grid-spacing-value">-</span>
 							</div>
 						</div>
@@ -61,61 +64,67 @@
 			</div>
 		</div>
 		<div>
-		<div class="col-md-4">
-			{% if model.is_hidden %}
-			<div class="panel panel-danger">
-			{% else %}
-			<div class="panel panel-primary">
-			{% endif %}
-				<div class="panel-heading">
-					<h3 class="panel-title">
-						{{ model.title }} 
-						{% if not latest_page %}
-							<small style="cursor:help;" title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
-							(Revision {{ model.revision }})
-							</small>
+			<div class="col-md-4">
+				{% if model.is_hidden %}
+				<div class="panel panel-danger">
+					{% else %}
+					<div class="panel panel-primary">
 						{% endif %}
-						
-					</h3>
-				</div>
-					<div class="panel-body" style="padding:0px;">
-						<ul class="nav nav-tabs" role="tablist">
-							<li role="presentation" class="active"><a href="#overview" aria-controls="overview" role="tab" data-toggle="tab">Overview</a></li>
-							<li role="presentation"><a href="#stats" aria-controls="stats" role="tab" data-toggle="tab">Stats</a></li>
-							<li role="presentation"><a href="#history" aria-controls="history" role="tab" data-toggle="tab">History</a></li>
-						</ul>
-						<div class="tab-content">
-							<div role="tabpanel" class="tab-pane active" id="overview">
-								{% include 'mainapp/model_overview.html' %}
-							</div>
-							<div role="tabpanel" class="tab-pane" id="stats">
-								{% include 'mainapp/model_stats.html' %}
-							</div>
-							<div role="tabpanel" class="tab-pane" id="history">
-								{% include 'mainapp/model_history.html' %}
+						<div class="panel-heading">
+							<h3 class="panel-title">
+								{{ model.title }}
+								{% if not latest_page %}
+								<small style="cursor:help;"
+									title="This is {% if model.latest %}the latest version{% else %}an older version{% endif %}">
+									(Revision {{ model.revision }})
+								</small>
+								{% endif %}
+
+							</h3>
+						</div>
+						<div class="panel-body" style="padding:0px;">
+							<ul class="nav nav-tabs" role="tablist">
+								<li role="presentation" class="active"><a href="#overview" aria-controls="overview"
+										role="tab" data-toggle="tab">Overview</a></li>
+								<li role="presentation"><a href="#stats" aria-controls="stats" role="tab"
+										data-toggle="tab">Stats</a></li>
+								<li role="presentation"><a href="#history" aria-controls="history" role="tab"
+										data-toggle="tab">History</a></li>
+							</ul>
+							<div class="tab-content">
+								<div role="tabpanel" class="tab-pane active" id="overview">
+									{% include 'mainapp/model_overview.html' %}
+								</div>
+								<div role="tabpanel" class="tab-pane" id="stats">
+									{% include 'mainapp/model_stats.html' %}
+								</div>
+								<div role="tabpanel" class="tab-pane" id="history">
+									{% include 'mainapp/model_history.html' %}
+								</div>
 							</div>
 						</div>
 					</div>
 				</div>
 			</div>
-	</div>
-</div>
-<script>
-{% if model.location %}
-initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
-{% endif %}
-</script>
-{% endblock %}
-{% block footeradditions %}
-{% vite_asset 'src/main.js' %}
-<script>
-	window.addEventListener("load", function() {
-		setUpRenderPane();
-		setUpStats();
-	});
+		</div>
+		<script>
+			{% if model.location %}
+			initMap("mapdiv", {{ model.location.latitude }}, {{ model.location.longitude }}, 750, 480);
+			{% endif %}
+		</script>
+		{% endblock %}
+		{% block footeradditions %}
+		{% vite_asset 'src/main.js' %}
+		<script>
+			window.addEventListener("load", function () {
+				setUpRenderPane(function (gltf) {
+					const stats = new ModelStats();
+					stats.processModel(gltf);
+				});
+			});
 
-	confirmDeleteModel = function() {
-		return confirm("Are you sure you want to delete this model? This action cannot be undone.");
-	};
-</script>
-{% endblock %}
+			confirmDeleteModel = function () {
+				return confirm("Are you sure you want to delete this model? This action cannot be undone.");
+			};
+		</script>
+		{% endblock %}

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -3,9 +3,7 @@
 {% if form_file %}
 {% endif %}
 
-<form
-	action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}"
-	method="post" enctype="multipart/form-data" {% if form_metadata %} onsubmit="return checkNumbers();" {% endif %}>
+<form action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}" method="post" enctype="multipart/form-data" {% if form_metadata %} onsubmit="return checkNumbers();" {% endif %}>
 	{% csrf_token %}
 	{% if form_metadata %}
 	<div class="form-group required">
@@ -18,15 +16,15 @@
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
 		{% for error in form.model_file.errors.as_data %}
-		<div class="alert alert-danger" role="alert">
-			{{ error.message }}
-			{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
-			<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
-				View Details
-			</button>
-			{% endif %}
-		</div>
-		{% endfor %}
+			<div class="alert alert-danger" role="alert">
+				{{ error.message }}
+				{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
+				<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
+					View Details
+				</button>
+				{% endif %}
+			</div>
+			{% endfor %}
 		{{ form.model_file }}
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
@@ -51,8 +49,7 @@
 		</div>
 	</div>
 	<div id="model-status"></div>
-	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line
-		with the world directions.</span>
+	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line with the world directions.</span>
 	{% endif %}
 	{% if form_metadata %}
 	<div class="form-group">
@@ -73,7 +70,6 @@
 	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
-
 	<div class="row flex" style="justify-content: space-between;">
 		<div class="form-group" style="width: 45%;">
 			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
@@ -127,14 +123,14 @@
 	}
 
 	function createMarker(lat, lon) {
-		marker = new L.marker([lat, lon], { draggable: true }).addTo(map);
-		marker.on('drag', function (e) {
+		marker = new L.marker([lat, lon], {draggable: true}).addTo(map);
+		marker.on('drag', function(e) {
 			updateLatLon(e.latlng.lat, e.latlng.lng);
 		});
 	}
 
 	var map = L.map('map');
-	map.on('load', function () {
+	map.on('load', function() {
 		var descriptor = document.getElementById('map-descriptor');
 		descriptor.innerHTML = 'Click anywhere on the map to set approximate longitude/latitude values.<br/>This will only be attached to the model\'s metadata.';
 	});
@@ -151,13 +147,13 @@
 	var latitude = parseFloat(document.getElementById('id_latitude').value);
 	var longitude = parseFloat(document.getElementById('id_longitude').value);
 
-	if (latitude && longitude) {
+	if(latitude && longitude) {
 		updateLatLon(latitude, longitude);
 		createMarker(latitude, longitude);
 	}
 
-	map.on('click', function (e) {
-		if (marker)
+	map.on('click', function(e) {
+		if(marker)
 			marker.remove(map);
 
 		updateLatLon(e.latlng.lat, e.latlng.lng);
@@ -173,35 +169,35 @@
 	function checkNumbers() {
 		var data = {
 			latitude: ['{{ form.latitude.id_for_label }}', -90, 90],
-			longitude: ['{{ form.longitude.id_for_label }}', -180, 180],
+			longitude: ['{{ form.longitude.id_for_label }}',-180, 180],
 		}
 
 		ok = true;
 
-		for (k in data) {
+		for(k in data) {
 			var arr = data[k];
 			var element = document.getElementById(arr[0]);
 			var valueString = element.value;
 
-			if (valueString == '')
+			if(valueString == '')
 				continue;
 
 			var value = parseFloat(valueString.replace(',', '.'));
 			console.log(value);
-			if (isNaN(value)) {
+			if(isNaN(value)) {
 				displayError(k, "Must be a number.");
 				ok = false;
 				continue;
 			}
 		}
 
-		if (!ok)
+		if(!ok)
 			displayError('form', 'Recheck the form for errors.');
 
 		return ok;
 	}
 
-	document.addEventListener('DOMContentLoaded', function () {
+	document.addEventListener('DOMContentLoaded', function() {
 		const licenseHelp = document.getElementById('license-help');
 		const radioButtons = document.querySelectorAll('input[name="model_source"]');
 		const modelSource = document.getElementById('model-source');
@@ -214,7 +210,7 @@
 		}
 
 		radioButtons.forEach(radio => {
-			radio.addEventListener('change', function () {
+			radio.addEventListener('change', function() {
 				toogle(this.value);
 			});
 		});
@@ -231,31 +227,31 @@
 {% vite_asset 'src/main.js' %}
 <script type="module">
 	document.getElementById('{{ form.model_file.id_for_label }}')
-		.addEventListener("change", function (event) {
-			const file = event.target.files[0];
-			if (file) {
-				const fileURL = URL.createObjectURL(file);
+	.addEventListener("change", function (event) {
+		const file = event.target.files[0];
+		if (file) {
+			const fileURL = URL.createObjectURL(file);
 
 
-				const options = { "width": "400", "height": "350" }
+			const options = { "width": "400", "height": "350" }
 
-				const renderPane = document.getElementById("render-pane");
-				const canvases = document.getElementsByTagName("canvas");
+			const renderPane = document.getElementById("render-pane");
+			const canvases = document.getElementsByTagName("canvas");
 
-				for (const element of canvases) {
-					if (renderPane.contains(element)) {
-						renderPane.removeChild(element);
-					}
+			for (const element of canvases) {
+				if (renderPane.contains(element)) {
+					renderPane.removeChild(element);
 				}
-
-				displayPreview("render-pane", fileURL, options, function (gltf) {
-					const stats = new ModelStats();
-					stats.processModel(gltf);
-				});
-			} else {
-				document.getElementById("model-preview").style.display = "none";
 			}
-		});
+
+			displayPreview("render-pane", fileURL, options, function (gltf) {
+				const stats = new ModelStats();
+				stats.processModel(gltf);
+			});
+		} else {
+			document.getElementById("model-preview").style.display = "none";
+		}
+	});
 </script>
 {% endif %}
 
@@ -264,50 +260,50 @@
 {% endif %}
 
 <script>
-	function showGlbErrors() {
-		const errorsDataElement = document.getElementById('glb-errors-data');
-		if (!errorsDataElement) return;
+function showGlbErrors() {
+	const errorsDataElement = document.getElementById('glb-errors-data');
+	if (!errorsDataElement) return;
 
-		const errors = JSON.parse(errorsDataElement.textContent);
+	const errors = JSON.parse(errorsDataElement.textContent);
 
-		const popup = window.open('', 'GLB Validation Errors', 'popup');
+	const popup = window.open('', 'GLB Validation Errors', 'popup');
 
-		let tableContent = '';
-		errors.forEach((error, index) => {
-			tableContent += `
-            <tr>
-                <td>${index + 1}</td>
-                <td>${error.message}</td>
-                <td><code>${error.pointer}</code></td>
-            </tr>
-        `;
-		});
+	let tableContent = '';
+	errors.forEach((error, index) => {
+		tableContent += `
+		<tr>
+			<td>${index + 1}</td>
+			<td>${error.message}</td>
+			<td><code>${error.pointer}</code></td>
+		</tr>
+	`;
+	});
 
-		popup.document.write(`
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title>GLB Validation Errors</title>
-			<link rel="stylesheet" href="{% static 'mainapp/lib/bootstrap.min.css' %}">
-        </head>
-        <body>
-            <h2>GLB Validation Errors</h2>
-            <p>The following errors were found in the uploaded GLB file:</p>
-            <table class="table table-striped table-bordered">
-                <thead>
-                    <tr>
-                        <th>#</th>
-                        <th>Error Message</th>
-                        <th>Node Pointer</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    ${tableContent}
-                </tbody>
-            </table>
-        </body>
-        </html>
-    `);
-		popup.document.close();
-	}
+	popup.document.write(`
+	<!DOCTYPE html>
+	<html>
+	<head>
+		<title>GLB Validation Errors</title>
+		<link rel="stylesheet" href="{% static 'mainapp/lib/bootstrap.min.css' %}">
+	</head>
+	<body>
+		<h2>GLB Validation Errors</h2>
+		<p>The following errors were found in the uploaded GLB file:</p>
+		<table class="table table-striped table-bordered">
+			<thead>
+				<tr>
+					<th>#</th>
+					<th>Error Message</th>
+					<th>Node Pointer</th>
+				</tr>
+			</thead>
+			<tbody>
+				${tableContent}
+			</tbody>
+		</table>
+	</body>
+	</html>
+`);
+	popup.document.close();
+}
 </script>

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -16,15 +16,15 @@
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
 		{% for error in form.model_file.errors.as_data %}
-            <div class="alert alert-danger" role="alert">
-                {{ error.message }}
-                {% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
-                    <button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
-                        View Details
-                    </button>
-                {% endif %}
-            </div>
-        {% endfor %}
+		<div class="alert alert-danger" role="alert">
+			{{ error.message }}
+			{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
+			<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
+				View Details
+			</button>
+			{% endif %}
+		</div>
+		{% endfor %}
 		{{ form.model_file }}
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
@@ -35,7 +35,7 @@
 					<div id="fullscreen-button">&#x26F6;</div>
 					<div id="labels-container"></div>
 					<div id="scale-container" style="display: none;">
-						<span>Grid Spacing:</span> 
+						<span>Grid Spacing:</span>
 						<span id="grid-spacing-value">-</span>
 					</div>
 				</div>
@@ -49,7 +49,8 @@
 		</div>
 	</div>
 	<div id="model-status"></div>
-	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line with the world directions.</span>
+	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line
+		with the world directions.</span>
 	{% endif %}
 	{% if form_metadata %}
 	<div class="form-group">
@@ -70,7 +71,7 @@
 	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
-	
+
 	<div class="row flex" style="justify-content: space-between;">
 		<div class="form-group" style="width: 45%;">
 			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
@@ -99,7 +100,8 @@
 		{% for error in form.source.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		<div class="alert alert-danger" role="alert" id="source-error" style="display: none;"></div>
 		{{ form.source }}
-		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a link isn't available, briefly describe where it came from.</span>
+		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a
+			link isn't available, briefly describe where it came from.</span>
 	</div>
 	<div class="form-group">
 		<label>License</label>
@@ -123,14 +125,14 @@
 	}
 
 	function createMarker(lat, lon) {
-		marker = new L.marker([lat, lon], {draggable: true}).addTo(map);
-		marker.on('drag', function(e) {
+		marker = new L.marker([lat, lon], { draggable: true }).addTo(map);
+		marker.on('drag', function (e) {
 			updateLatLon(e.latlng.lat, e.latlng.lng);
 		});
 	}
 
 	var map = L.map('map');
-	map.on('load', function() {
+	map.on('load', function () {
 		var descriptor = document.getElementById('map-descriptor');
 		descriptor.innerHTML = 'Click anywhere on the map to set approximate longitude/latitude values.<br/>This will only be attached to the model\'s metadata.';
 	});
@@ -147,15 +149,15 @@
 	var latitude = parseFloat(document.getElementById('id_latitude').value);
 	var longitude = parseFloat(document.getElementById('id_longitude').value);
 
-	if(latitude && longitude) {
+	if (latitude && longitude) {
 		updateLatLon(latitude, longitude);
 		createMarker(latitude, longitude);
 	}
 
-	map.on('click', function(e) {
-		if(marker)
+	map.on('click', function (e) {
+		if (marker)
 			marker.remove(map);
-		
+
 		updateLatLon(e.latlng.lat, e.latlng.lng);
 		createMarker(e.latlng.lat, e.latlng.lng);
 	});
@@ -169,57 +171,57 @@
 	function checkNumbers() {
 		var data = {
 			latitude: ['{{ form.latitude.id_for_label }}', -90, 90],
-			longitude: ['{{ form.longitude.id_for_label }}',-180, 180],
+			longitude: ['{{ form.longitude.id_for_label }}', -180, 180],
 		}
 
 		ok = true;
 
-		for(k in data) {
+		for (k in data) {
 			var arr = data[k];
 			var element = document.getElementById(arr[0]);
 			var valueString = element.value;
 
-			if(valueString == '')
+			if (valueString == '')
 				continue;
 
 			var value = parseFloat(valueString.replace(',', '.'));
 			console.log(value);
-			if(isNaN(value)) {
+			if (isNaN(value)) {
 				displayError(k, "Must be a number.");
 				ok = false;
 				continue;
 			}
 		}
 
-		if(!ok)
+		if (!ok)
 			displayError('form', 'Recheck the form for errors.');
 
 		return ok;
 	}
 
-    document.addEventListener('DOMContentLoaded', function() {
-        const licenseHelp = document.getElementById('license-help');
-        const radioButtons = document.querySelectorAll('input[name="model_source"]');
-        const modelSource = document.getElementById('model-source');
+	document.addEventListener('DOMContentLoaded', function () {
+		const licenseHelp = document.getElementById('license-help');
+		const radioButtons = document.querySelectorAll('input[name="model_source"]');
+		const modelSource = document.getElementById('model-source');
 
-        function toogle(selectedValue) {
-            licenseHelp.innerHTML = selectedValue !== 'self_created' ?
-                'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
-                '';
-            modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
-        }
+		function toogle(selectedValue) {
+			licenseHelp.innerHTML = selectedValue !== 'self_created' ?
+				'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
+				'';
+			modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
+		}
 
-        radioButtons.forEach(radio => {
-            radio.addEventListener('change', function() {
-                toogle(this.value);
-            });
-        });
+		radioButtons.forEach(radio => {
+			radio.addEventListener('change', function () {
+				toogle(this.value);
+			});
+		});
 
-        const selectedRadio = document.querySelector('input[name="model_source"]:checked');
-        if (selectedRadio) {
-            toogle(selectedRadio.value);
-        }
-    });
+		const selectedRadio = document.querySelector('input[name="model_source"]:checked');
+		if (selectedRadio) {
+			toogle(selectedRadio.value);
+		}
+	});
 </script>
 {% endif %}
 
@@ -227,30 +229,31 @@
 {% vite_asset 'src/main.js' %}
 <script type="module">
 	document.getElementById('{{ form.model_file.id_for_label }}')
-	.addEventListener("change", function (event) {
-		const file = event.target.files[0];
-		if (file) {
-			const fileURL = URL.createObjectURL(file);
-			
-			const options = {"width": "400", "height": "350"}
-			
-			const renderPane = document.getElementById("render-pane");
-			const canvases = document.getElementsByTagName("canvas");
+		.addEventListener("change", function (event) {
+			const file = event.target.files[0];
+			if (file) {
+				const fileURL = URL.createObjectURL(file);
 
-			for (const element of canvases) {
-				if (renderPane.contains(element)) {
-					renderPane.removeChild(element);
+				const options = { width: 400, height: 350 };
+				const model_preview = document.getElementById("model-preview");
+				const renderPane = document.getElementById("render-pane");
+				const canvases = document.getElementsByTagName("canvas");
+				for (const canvas of canvases) {
+					if (renderPane.contains(canvas)) {
+						renderPane.removeChild(canvas);
+					}
 				}
+
+				model_preview.style.display = "block";
+				const preview = new ModelPreview("render-pane", options);
+				preview.loadAndDisplay(fileURL, function (gltf) {
+					const stats = new ModelStats();
+					stats.processModel(gltf);
+				});
+			} else {
+				document.getElementById("model-preview").style.display = "none";
 			}
-			
-			displayPreview("render-pane", fileURL, options, function (gltf) {
-				const stats = new ModelStats();
-				stats.processModel(gltf);
-			});
-		} else {
-			document.getElementById("model-preview").style.display = "none";
-		}
-	});
+		});
 </script>
 {% endif %}
 
@@ -259,26 +262,26 @@
 {% endif %}
 
 <script>
-function showGlbErrors() {
-    const errorsDataElement = document.getElementById('glb-errors-data');
-    if (!errorsDataElement) return;
+	function showGlbErrors() {
+		const errorsDataElement = document.getElementById('glb-errors-data');
+		if (!errorsDataElement) return;
 
-    const errors = JSON.parse(errorsDataElement.textContent);
-    
-    const popup = window.open('', 'GLB Validation Errors', 'popup');
-    
-    let tableContent = '';
-    errors.forEach((error, index) => {
-        tableContent += `
+		const errors = JSON.parse(errorsDataElement.textContent);
+
+		const popup = window.open('', 'GLB Validation Errors', 'popup');
+
+		let tableContent = '';
+		errors.forEach((error, index) => {
+			tableContent += `
             <tr>
                 <td>${index + 1}</td>
                 <td>${error.message}</td>
                 <td><code>${error.pointer}</code></td>
             </tr>
         `;
-    });
+		});
 
-    popup.document.write(`
+		popup.document.write(`
         <!DOCTYPE html>
         <html>
         <head>
@@ -303,6 +306,6 @@ function showGlbErrors() {
         </body>
         </html>
     `);
-    popup.document.close();
-}
+		popup.document.close();
+	}
 </script>

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -231,8 +231,6 @@
 		const file = event.target.files[0];
 		if (file) {
 			const fileURL = URL.createObjectURL(file);
-
-			initStatsTHREE(fileURL);
 			
 			const options = {"width": "400", "height": "350"}
 			
@@ -245,11 +243,12 @@
 				}
 			}
 			
-			const preview = new ModelPreview("render-pane", options);
-			preview.loadAndDisplay(fileURL, function (gltf) {
-				const stats = new ModelStats();
-				stats.processModel(gltf);
-			});
+			document.getElementById("model-preview").style.display = "block";
+				const preview = new ModelPreview("render-pane", options);
+				preview.loadAndDisplay(fileURL, function (gltf) {
+					const stats = new ModelStats();
+					stats.processModel(gltf);
+				});
 		} else {
 			document.getElementById("model-preview").style.display = "none";
 		}

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -3,7 +3,9 @@
 {% if form_file %}
 {% endif %}
 
-<form action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}" method="post" enctype="multipart/form-data"{% if form_metadata %} onsubmit="return checkNumbers();"{% endif %}>
+<form
+	action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}"
+	method="post" enctype="multipart/form-data" {% if form_metadata %} onsubmit="return checkNumbers();" {% endif %}>
 	{% csrf_token %}
 	{% if form_metadata %}
 	<div class="form-group required">
@@ -16,15 +18,15 @@
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
 		{% for error in form.model_file.errors.as_data %}
-            <div class="alert alert-danger" role="alert">
-                {{ error.message }}
-                {% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
-                    <button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
-                        View Details
-                    </button>
-                {% endif %}
-            </div>
-        {% endfor %}
+		<div class="alert alert-danger" role="alert">
+			{{ error.message }}
+			{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
+			<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
+				View Details
+			</button>
+			{% endif %}
+		</div>
+		{% endfor %}
 		{{ form.model_file }}
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
@@ -35,7 +37,7 @@
 					<div id="fullscreen-button">&#x26F6;</div>
 					<div id="labels-container"></div>
 					<div id="scale-container" style="display: none;">
-						<span>Grid Spacing:</span> 
+						<span>Grid Spacing:</span>
 						<span id="grid-spacing-value">-</span>
 					</div>
 				</div>
@@ -49,7 +51,8 @@
 		</div>
 	</div>
 	<div id="model-status"></div>
-	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line with the world directions.</span>
+	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line
+		with the world directions.</span>
 	{% endif %}
 	{% if form_metadata %}
 	<div class="form-group">
@@ -70,7 +73,7 @@
 	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
-	
+
 	<div class="row flex" style="justify-content: space-between;">
 		<div class="form-group" style="width: 45%;">
 			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
@@ -99,7 +102,8 @@
 		{% for error in form.source.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		<div class="alert alert-danger" role="alert" id="source-error" style="display: none;"></div>
 		{{ form.source }}
-		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a link isn't available, briefly describe where it came from.</span>
+		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a
+			link isn't available, briefly describe where it came from.</span>
 	</div>
 	<div class="form-group">
 		<label>License</label>
@@ -123,14 +127,14 @@
 	}
 
 	function createMarker(lat, lon) {
-		marker = new L.marker([lat, lon], {draggable: true}).addTo(map);
-		marker.on('drag', function(e) {
+		marker = new L.marker([lat, lon], { draggable: true }).addTo(map);
+		marker.on('drag', function (e) {
 			updateLatLon(e.latlng.lat, e.latlng.lng);
 		});
 	}
 
 	var map = L.map('map');
-	map.on('load', function() {
+	map.on('load', function () {
 		var descriptor = document.getElementById('map-descriptor');
 		descriptor.innerHTML = 'Click anywhere on the map to set approximate longitude/latitude values.<br/>This will only be attached to the model\'s metadata.';
 	});
@@ -147,15 +151,15 @@
 	var latitude = parseFloat(document.getElementById('id_latitude').value);
 	var longitude = parseFloat(document.getElementById('id_longitude').value);
 
-	if(latitude && longitude) {
+	if (latitude && longitude) {
 		updateLatLon(latitude, longitude);
 		createMarker(latitude, longitude);
 	}
 
-	map.on('click', function(e) {
-		if(marker)
+	map.on('click', function (e) {
+		if (marker)
 			marker.remove(map);
-		
+
 		updateLatLon(e.latlng.lat, e.latlng.lng);
 		createMarker(e.latlng.lat, e.latlng.lng);
 	});
@@ -169,57 +173,57 @@
 	function checkNumbers() {
 		var data = {
 			latitude: ['{{ form.latitude.id_for_label }}', -90, 90],
-			longitude: ['{{ form.longitude.id_for_label }}',-180, 180],
+			longitude: ['{{ form.longitude.id_for_label }}', -180, 180],
 		}
 
 		ok = true;
 
-		for(k in data) {
+		for (k in data) {
 			var arr = data[k];
 			var element = document.getElementById(arr[0]);
 			var valueString = element.value;
 
-			if(valueString == '')
+			if (valueString == '')
 				continue;
 
 			var value = parseFloat(valueString.replace(',', '.'));
 			console.log(value);
-			if(isNaN(value)) {
+			if (isNaN(value)) {
 				displayError(k, "Must be a number.");
 				ok = false;
 				continue;
 			}
 		}
 
-		if(!ok)
+		if (!ok)
 			displayError('form', 'Recheck the form for errors.');
 
 		return ok;
 	}
 
-    document.addEventListener('DOMContentLoaded', function() {
-        const licenseHelp = document.getElementById('license-help');
-        const radioButtons = document.querySelectorAll('input[name="model_source"]');
-        const modelSource = document.getElementById('model-source');
+	document.addEventListener('DOMContentLoaded', function () {
+		const licenseHelp = document.getElementById('license-help');
+		const radioButtons = document.querySelectorAll('input[name="model_source"]');
+		const modelSource = document.getElementById('model-source');
 
-        function toogle(selectedValue) {
-            licenseHelp.innerHTML = selectedValue !== 'self_created' ?
-                'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
-                '';
-            modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
-        }
+		function toogle(selectedValue) {
+			licenseHelp.innerHTML = selectedValue !== 'self_created' ?
+				'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
+				'';
+			modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
+		}
 
-        radioButtons.forEach(radio => {
-            radio.addEventListener('change', function() {
-                toogle(this.value);
-            });
-        });
+		radioButtons.forEach(radio => {
+			radio.addEventListener('change', function () {
+				toogle(this.value);
+			});
+		});
 
-        const selectedRadio = document.querySelector('input[name="model_source"]:checked');
-        if (selectedRadio) {
-            toogle(selectedRadio.value);
-        }
-    });
+		const selectedRadio = document.querySelector('input[name="model_source"]:checked');
+		if (selectedRadio) {
+			toogle(selectedRadio.value);
+		}
+	});
 </script>
 {% endif %}
 
@@ -227,29 +231,31 @@
 {% vite_asset 'src/main.js' %}
 <script type="module">
 	document.getElementById('{{ form.model_file.id_for_label }}')
-	.addEventListener("change", function (event) {
-		const file = event.target.files[0];
-		if (file) {
-			const fileURL = URL.createObjectURL(file);
+		.addEventListener("change", function (event) {
+			const file = event.target.files[0];
+			if (file) {
+				const fileURL = URL.createObjectURL(file);
 
-			initStatsTHREE(fileURL);
-			
-			const options = {"width": "400", "height": "350"}
-			
-			const renderPane = document.getElementById("render-pane");
-			const canvases = document.getElementsByTagName("canvas");
 
-			for (const element of canvases) {
-				if (renderPane.contains(element)) {
-					renderPane.removeChild(element);
+				const options = { "width": "400", "height": "350" }
+
+				const renderPane = document.getElementById("render-pane");
+				const canvases = document.getElementsByTagName("canvas");
+
+				for (const element of canvases) {
+					if (renderPane.contains(element)) {
+						renderPane.removeChild(element);
+					}
 				}
+
+				displayPreview("render-pane", fileURL, options, function (gltf) {
+					const stats = new ModelStats();
+					stats.processModel(gltf);
+				});
+			} else {
+				document.getElementById("model-preview").style.display = "none";
 			}
-			
-			displayPreview("render-pane", fileURL, options);
-		} else {
-			document.getElementById("model-preview").style.display = "none";
-		}
-	});
+		});
 </script>
 {% endif %}
 
@@ -258,26 +264,26 @@
 {% endif %}
 
 <script>
-function showGlbErrors() {
-    const errorsDataElement = document.getElementById('glb-errors-data');
-    if (!errorsDataElement) return;
+	function showGlbErrors() {
+		const errorsDataElement = document.getElementById('glb-errors-data');
+		if (!errorsDataElement) return;
 
-    const errors = JSON.parse(errorsDataElement.textContent);
-    
-    const popup = window.open('', 'GLB Validation Errors', 'popup');
-    
-    let tableContent = '';
-    errors.forEach((error, index) => {
-        tableContent += `
+		const errors = JSON.parse(errorsDataElement.textContent);
+
+		const popup = window.open('', 'GLB Validation Errors', 'popup');
+
+		let tableContent = '';
+		errors.forEach((error, index) => {
+			tableContent += `
             <tr>
                 <td>${index + 1}</td>
                 <td>${error.message}</td>
                 <td><code>${error.pointer}</code></td>
             </tr>
         `;
-    });
+		});
 
-    popup.document.write(`
+		popup.document.write(`
         <!DOCTYPE html>
         <html>
         <head>
@@ -302,6 +308,6 @@ function showGlbErrors() {
         </body>
         </html>
     `);
-    popup.document.close();
-}
+		popup.document.close();
+	}
 </script>

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -231,8 +231,6 @@
 		const file = event.target.files[0];
 		if (file) {
 			const fileURL = URL.createObjectURL(file);
-
-			initStatsTHREE(fileURL);
 			
 			const options = {"width": "400", "height": "350"}
 			

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -16,15 +16,15 @@
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
 		{% for error in form.model_file.errors.as_data %}
-		<div class="alert alert-danger" role="alert">
-			{{ error.message }}
-			{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
-			<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
-				View Details
-			</button>
-			{% endif %}
-		</div>
-		{% endfor %}
+            <div class="alert alert-danger" role="alert">
+                {{ error.message }}
+                {% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
+                    <button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
+                        View Details
+                    </button>
+                {% endif %}
+            </div>
+        {% endfor %}
 		{{ form.model_file }}
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
@@ -35,7 +35,7 @@
 					<div id="fullscreen-button">&#x26F6;</div>
 					<div id="labels-container"></div>
 					<div id="scale-container" style="display: none;">
-						<span>Grid Spacing:</span>
+						<span>Grid Spacing:</span> 
 						<span id="grid-spacing-value">-</span>
 					</div>
 				</div>
@@ -49,8 +49,7 @@
 		</div>
 	</div>
 	<div id="model-status"></div>
-	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line
-		with the world directions.</span>
+	<span class="help-block">Please use the full screen preview above to ensure that your model's alignment is in line with the world directions.</span>
 	{% endif %}
 	{% if form_metadata %}
 	<div class="form-group">
@@ -71,7 +70,7 @@
 	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
-
+	
 	<div class="row flex" style="justify-content: space-between;">
 		<div class="form-group" style="width: 45%;">
 			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
@@ -100,8 +99,7 @@
 		{% for error in form.source.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		<div class="alert alert-danger" role="alert" id="source-error" style="display: none;"></div>
 		{{ form.source }}
-		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a
-			link isn't available, briefly describe where it came from.</span>
+		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a link isn't available, briefly describe where it came from.</span>
 	</div>
 	<div class="form-group">
 		<label>License</label>
@@ -125,14 +123,14 @@
 	}
 
 	function createMarker(lat, lon) {
-		marker = new L.marker([lat, lon], { draggable: true }).addTo(map);
-		marker.on('drag', function (e) {
+		marker = new L.marker([lat, lon], {draggable: true}).addTo(map);
+		marker.on('drag', function(e) {
 			updateLatLon(e.latlng.lat, e.latlng.lng);
 		});
 	}
 
 	var map = L.map('map');
-	map.on('load', function () {
+	map.on('load', function() {
 		var descriptor = document.getElementById('map-descriptor');
 		descriptor.innerHTML = 'Click anywhere on the map to set approximate longitude/latitude values.<br/>This will only be attached to the model\'s metadata.';
 	});
@@ -149,15 +147,15 @@
 	var latitude = parseFloat(document.getElementById('id_latitude').value);
 	var longitude = parseFloat(document.getElementById('id_longitude').value);
 
-	if (latitude && longitude) {
+	if(latitude && longitude) {
 		updateLatLon(latitude, longitude);
 		createMarker(latitude, longitude);
 	}
 
-	map.on('click', function (e) {
-		if (marker)
+	map.on('click', function(e) {
+		if(marker)
 			marker.remove(map);
-
+		
 		updateLatLon(e.latlng.lat, e.latlng.lng);
 		createMarker(e.latlng.lat, e.latlng.lng);
 	});
@@ -171,57 +169,57 @@
 	function checkNumbers() {
 		var data = {
 			latitude: ['{{ form.latitude.id_for_label }}', -90, 90],
-			longitude: ['{{ form.longitude.id_for_label }}', -180, 180],
+			longitude: ['{{ form.longitude.id_for_label }}',-180, 180],
 		}
 
 		ok = true;
 
-		for (k in data) {
+		for(k in data) {
 			var arr = data[k];
 			var element = document.getElementById(arr[0]);
 			var valueString = element.value;
 
-			if (valueString == '')
+			if(valueString == '')
 				continue;
 
 			var value = parseFloat(valueString.replace(',', '.'));
 			console.log(value);
-			if (isNaN(value)) {
+			if(isNaN(value)) {
 				displayError(k, "Must be a number.");
 				ok = false;
 				continue;
 			}
 		}
 
-		if (!ok)
+		if(!ok)
 			displayError('form', 'Recheck the form for errors.');
 
 		return ok;
 	}
 
-	document.addEventListener('DOMContentLoaded', function () {
-		const licenseHelp = document.getElementById('license-help');
-		const radioButtons = document.querySelectorAll('input[name="model_source"]');
-		const modelSource = document.getElementById('model-source');
+    document.addEventListener('DOMContentLoaded', function() {
+        const licenseHelp = document.getElementById('license-help');
+        const radioButtons = document.querySelectorAll('input[name="model_source"]');
+        const modelSource = document.getElementById('model-source');
 
-		function toogle(selectedValue) {
-			licenseHelp.innerHTML = selectedValue !== 'self_created' ?
-				'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
-				'';
-			modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
-		}
+        function toogle(selectedValue) {
+            licenseHelp.innerHTML = selectedValue !== 'self_created' ?
+                'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
+                '';
+            modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
+        }
 
-		radioButtons.forEach(radio => {
-			radio.addEventListener('change', function () {
-				toogle(this.value);
-			});
-		});
+        radioButtons.forEach(radio => {
+            radio.addEventListener('change', function() {
+                toogle(this.value);
+            });
+        });
 
-		const selectedRadio = document.querySelector('input[name="model_source"]:checked');
-		if (selectedRadio) {
-			toogle(selectedRadio.value);
-		}
-	});
+        const selectedRadio = document.querySelector('input[name="model_source"]:checked');
+        if (selectedRadio) {
+            toogle(selectedRadio.value);
+        }
+    });
 </script>
 {% endif %}
 
@@ -229,31 +227,33 @@
 {% vite_asset 'src/main.js' %}
 <script type="module">
 	document.getElementById('{{ form.model_file.id_for_label }}')
-		.addEventListener("change", function (event) {
-			const file = event.target.files[0];
-			if (file) {
-				const fileURL = URL.createObjectURL(file);
+	.addEventListener("change", function (event) {
+		const file = event.target.files[0];
+		if (file) {
+			const fileURL = URL.createObjectURL(file);
 
-				const options = { width: 400, height: 350 };
-				const model_preview = document.getElementById("model-preview");
-				const renderPane = document.getElementById("render-pane");
-				const canvases = document.getElementsByTagName("canvas");
-				for (const canvas of canvases) {
-					if (renderPane.contains(canvas)) {
-						renderPane.removeChild(canvas);
-					}
+			initStatsTHREE(fileURL);
+			
+			const options = {"width": "400", "height": "350"}
+			
+			const renderPane = document.getElementById("render-pane");
+			const canvases = document.getElementsByTagName("canvas");
+
+			for (const element of canvases) {
+				if (renderPane.contains(element)) {
+					renderPane.removeChild(element);
 				}
-
-				model_preview.style.display = "block";
-				const preview = new ModelPreview("render-pane", options);
-				preview.loadAndDisplay(fileURL, function (gltf) {
-					const stats = new ModelStats();
-					stats.processModel(gltf);
-				});
-			} else {
-				document.getElementById("model-preview").style.display = "none";
 			}
-		});
+			
+			const preview = new ModelPreview("render-pane", options);
+			preview.loadAndDisplay(fileURL, function (gltf) {
+				const stats = new ModelStats();
+				stats.processModel(gltf);
+			});
+		} else {
+			document.getElementById("model-preview").style.display = "none";
+		}
+	});
 </script>
 {% endif %}
 
@@ -262,26 +262,26 @@
 {% endif %}
 
 <script>
-	function showGlbErrors() {
-		const errorsDataElement = document.getElementById('glb-errors-data');
-		if (!errorsDataElement) return;
+function showGlbErrors() {
+    const errorsDataElement = document.getElementById('glb-errors-data');
+    if (!errorsDataElement) return;
 
-		const errors = JSON.parse(errorsDataElement.textContent);
-
-		const popup = window.open('', 'GLB Validation Errors', 'popup');
-
-		let tableContent = '';
-		errors.forEach((error, index) => {
-			tableContent += `
+    const errors = JSON.parse(errorsDataElement.textContent);
+    
+    const popup = window.open('', 'GLB Validation Errors', 'popup');
+    
+    let tableContent = '';
+    errors.forEach((error, index) => {
+        tableContent += `
             <tr>
                 <td>${index + 1}</td>
                 <td>${error.message}</td>
                 <td><code>${error.pointer}</code></td>
             </tr>
         `;
-		});
+    });
 
-		popup.document.write(`
+    popup.document.write(`
         <!DOCTYPE html>
         <html>
         <head>
@@ -306,6 +306,6 @@
         </body>
         </html>
     `);
-		popup.document.close();
-	}
+    popup.document.close();
+}
 </script>

--- a/mainapp/templates/mainapp/modelform.html
+++ b/mainapp/templates/mainapp/modelform.html
@@ -3,7 +3,7 @@
 {% if form_file %}
 {% endif %}
 
-<form action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}" method="post" enctype="multipart/form-data" {% if form_metadata %} onsubmit="return checkNumbers();" {% endif %}>
+<form action="{% if revise %}{% url 'revise' model.model_id %}{% elif edit %}{% url 'edit' model.model_id model.revision %}{% else %}{% url 'upload' %}{% endif %}" method="post" enctype="multipart/form-data"{% if form_metadata %} onsubmit="return checkNumbers();"{% endif %}>
 	{% csrf_token %}
 	{% if form_metadata %}
 	<div class="form-group required">
@@ -16,15 +16,15 @@
 	<div class="form-group required">
 		<label for="{{ form.model_file.id_for_label }}">{{ form.model_file.label }}</label>
 		{% for error in form.model_file.errors.as_data %}
-			<div class="alert alert-danger" role="alert">
-				{{ error.message }}
-				{% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
-				<button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
-					View Details
-				</button>
-				{% endif %}
-			</div>
-			{% endfor %}
+            <div class="alert alert-danger" role="alert">
+                {{ error.message }}
+                {% if error.code == 'glb_validation_failed' and form.model_file.field.glb_errors %}
+                    <button type="button" class="btn btn-danger btn-sm" onclick="showGlbErrors()">
+                        View Details
+                    </button>
+                {% endif %}
+            </div>
+        {% endfor %}
 		{{ form.model_file }}
 	</div>
 	<div id="model-preview" style="margin-bottom: 15px; display: none;">
@@ -35,7 +35,7 @@
 					<div id="fullscreen-button">&#x26F6;</div>
 					<div id="labels-container"></div>
 					<div id="scale-container" style="display: none;">
-						<span>Grid Spacing:</span>
+						<span>Grid Spacing:</span> 
 						<span id="grid-spacing-value">-</span>
 					</div>
 				</div>
@@ -70,6 +70,7 @@
 	<label for="map">Approximate position:</label>
 	<div id="map"></div>
 	<p id="map-descriptor"></p>
+	
 	<div class="row flex" style="justify-content: space-between;">
 		<div class="form-group" style="width: 45%;">
 			<label for="{{ form.latitude.id_for_label }}">{{ form.latitude.label }}:</label>
@@ -98,8 +99,7 @@
 		{% for error in form.source.errors %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endfor %}
 		<div class="alert alert-danger" role="alert" id="source-error" style="display: none;"></div>
 		{{ form.source }}
-		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a
-			link isn't available, briefly describe where it came from.</span>
+		<span id="source-help" class="help-block">If available, please provide a direct link to the source model. If a link isn't available, briefly describe where it came from.</span>
 	</div>
 	<div class="form-group">
 		<label>License</label>
@@ -155,7 +155,7 @@
 	map.on('click', function(e) {
 		if(marker)
 			marker.remove(map);
-
+		
 		updateLatLon(e.latlng.lat, e.latlng.lng);
 		createMarker(e.latlng.lat, e.latlng.lng);
 	});
@@ -197,29 +197,29 @@
 		return ok;
 	}
 
-	document.addEventListener('DOMContentLoaded', function() {
-		const licenseHelp = document.getElementById('license-help');
-		const radioButtons = document.querySelectorAll('input[name="model_source"]');
-		const modelSource = document.getElementById('model-source');
+    document.addEventListener('DOMContentLoaded', function() {
+        const licenseHelp = document.getElementById('license-help');
+        const radioButtons = document.querySelectorAll('input[name="model_source"]');
+        const modelSource = document.getElementById('model-source');
 
-		function toogle(selectedValue) {
-			licenseHelp.innerHTML = selectedValue !== 'self_created' ?
-				'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
-				'';
-			modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
-		}
+        function toogle(selectedValue) {
+            licenseHelp.innerHTML = selectedValue !== 'self_created' ?
+                'Please check the license of the source and make sure you are allowed to upload the model somewhere else <strong>without having to give attribution</strong>. Please also provide the original source.' :
+                '';
+            modelSource.style.display = selectedValue === 'self_created' ? 'none' : 'block';
+        }
 
-		radioButtons.forEach(radio => {
-			radio.addEventListener('change', function() {
-				toogle(this.value);
-			});
-		});
+        radioButtons.forEach(radio => {
+            radio.addEventListener('change', function() {
+                toogle(this.value);
+            });
+        });
 
-		const selectedRadio = document.querySelector('input[name="model_source"]:checked');
-		if (selectedRadio) {
-			toogle(selectedRadio.value);
-		}
-	});
+        const selectedRadio = document.querySelector('input[name="model_source"]:checked');
+        if (selectedRadio) {
+            toogle(selectedRadio.value);
+        }
+    });
 </script>
 {% endif %}
 
@@ -232,9 +232,10 @@
 		if (file) {
 			const fileURL = URL.createObjectURL(file);
 
-
-			const options = { "width": "400", "height": "350" }
-
+			initStatsTHREE(fileURL);
+			
+			const options = {"width": "400", "height": "350"}
+			
 			const renderPane = document.getElementById("render-pane");
 			const canvases = document.getElementsByTagName("canvas");
 
@@ -243,7 +244,7 @@
 					renderPane.removeChild(element);
 				}
 			}
-
+			
 			displayPreview("render-pane", fileURL, options, function (gltf) {
 				const stats = new ModelStats();
 				stats.processModel(gltf);
@@ -261,49 +262,49 @@
 
 <script>
 function showGlbErrors() {
-	const errorsDataElement = document.getElementById('glb-errors-data');
-	if (!errorsDataElement) return;
+    const errorsDataElement = document.getElementById('glb-errors-data');
+    if (!errorsDataElement) return;
 
-	const errors = JSON.parse(errorsDataElement.textContent);
+    const errors = JSON.parse(errorsDataElement.textContent);
+    
+    const popup = window.open('', 'GLB Validation Errors', 'popup');
+    
+    let tableContent = '';
+    errors.forEach((error, index) => {
+        tableContent += `
+            <tr>
+                <td>${index + 1}</td>
+                <td>${error.message}</td>
+                <td><code>${error.pointer}</code></td>
+            </tr>
+        `;
+    });
 
-	const popup = window.open('', 'GLB Validation Errors', 'popup');
-
-	let tableContent = '';
-	errors.forEach((error, index) => {
-		tableContent += `
-		<tr>
-			<td>${index + 1}</td>
-			<td>${error.message}</td>
-			<td><code>${error.pointer}</code></td>
-		</tr>
-	`;
-	});
-
-	popup.document.write(`
-	<!DOCTYPE html>
-	<html>
-	<head>
-		<title>GLB Validation Errors</title>
-		<link rel="stylesheet" href="{% static 'mainapp/lib/bootstrap.min.css' %}">
-	</head>
-	<body>
-		<h2>GLB Validation Errors</h2>
-		<p>The following errors were found in the uploaded GLB file:</p>
-		<table class="table table-striped table-bordered">
-			<thead>
-				<tr>
-					<th>#</th>
-					<th>Error Message</th>
-					<th>Node Pointer</th>
-				</tr>
-			</thead>
-			<tbody>
-				${tableContent}
-			</tbody>
-		</table>
-	</body>
-	</html>
-`);
-	popup.document.close();
+    popup.document.write(`
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>GLB Validation Errors</title>
+			<link rel="stylesheet" href="{% static 'mainapp/lib/bootstrap.min.css' %}">
+        </head>
+        <body>
+            <h2>GLB Validation Errors</h2>
+            <p>The following errors were found in the uploaded GLB file:</p>
+            <table class="table table-striped table-bordered">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Error Message</th>
+                        <th>Node Pointer</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${tableContent}
+                </tbody>
+            </table>
+        </body>
+        </html>
+    `);
+    popup.document.close();
 }
 </script>


### PR DESCRIPTION
In this PR, I have modified the `Function `structure code to the `Class` type in model_stats.js and preview.js which was actually required for many crucial reasons such as the ownership of the variables, lifecycle of the components, clean code and expecially no memory leaks.

Another change is that, We have removed the separate **GLB File Loading** for both the components stats and preview one.
This was achieved by loading the GLB file in the preview.js only and then parsing it and passing as a reference to the model_stats component, which then uses it to calculate the stats such as faceCount, meshCount etc.