### PR TITLE
Replace 400 Error in search_full API with Empty Model List

### DIFF
--- a/mainapp/api.py
+++ b/mainapp/api.py
@@ -216,7 +216,7 @@ def search_full(request):
             author = UserSocialAuth.objects.get(uid=data.get('author')).user
             models = models.filter(author=author)
         except UserSocialAuth.DoesNotExist:
-            return HttpResponseBadRequest('Author not found')
+            models = models.none()
 
     latitude = data.get('lat')
     longitude = data.get('lon')


### PR DESCRIPTION
If queried author does not exist, the API should return empty model list instead of 400 bad request.