### PR TITLE
Add default image path for leaflet marker image

### DIFF
--- a/mainapp/templates/mainapp/map.html
+++ b/mainapp/templates/mainapp/map.html
@@ -9,6 +9,7 @@
 {% compress js %}
 <script src="{% static 'mainapp/lib/leaflet.js' %}"></script>
 {% endcompress %}
+<script>L.Icon.Default.imagePath = "{% static 'mainapp/lib/images/' %}";</script>
 <style>
 	html, body {
 		width: 100%;

--- a/mainapp/templates/mainapp/model.html
+++ b/mainapp/templates/mainapp/model.html
@@ -5,6 +5,7 @@
 {% load django_vite %}
 <link rel="stylesheet" href="{% static 'mainapp/lib/leaflet.css' %}">
 <script src="{% static 'mainapp/lib/leaflet.js' %}"></script>
+<script>L.Icon.Default.imagePath = "{% static 'mainapp/lib/images/' %}";</script>
 <style>
 	#mapdiv {
 		width: 750px;


### PR DESCRIPTION
Closes #95 

This directs leaflet to look for maker images inside the correct `static/mainapp/lib/images/` directory.

Was able to reproduce the bug on my local and simulate the fix.