### PR TITLE
Allow Admin users to revise broken models

### DIFF
--- a/mainapp/database.py
+++ b/mainapp/database.py
@@ -30,7 +30,7 @@ def upload(model_file, options={}):
                 m.pk = None
                 m.id = None
                 m.revision += 1
-                m.author = options['author']
+                m.uploader = options['author']
                 m.location = location
                 m.latest = True
                 m._state.adding = True
@@ -68,6 +68,7 @@ def upload(model_file, options={}):
                     location=location,
                     license=options['license'],
                     author=options['author'],
+                    uploader=options['author'],
                     source=options['source'],
                     latest=True
                 )

--- a/mainapp/migrations/0008_model_uploader.py
+++ b/mainapp/migrations/0008_model_uploader.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def populate_uploader_field(apps, schema_editor):
+    """
+    Existing revisions were always uploaded by their author.
+    """
+
+    db_alias = schema_editor.connection.alias
+    Model = apps.get_model("mainapp", "Model")
+    Model.objects.using(db_alias).update(uploader=models.F("author"))
+
+
+def reverse_populate_uploader_field(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+    Model = apps.get_model("mainapp", "Model")
+    Model.objects.using(db_alias).update(uploader=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mainapp', '0007_update_osm_oauth2_provider'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='model',
+            name='uploader',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='uploaded_models', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.RunPython(populate_uploader_field, reverse_populate_uploader_field),
+    ]

--- a/mainapp/models.py
+++ b/mainapp/models.py
@@ -58,7 +58,11 @@ class Location(models.Model):
     longitude = models.FloatField()
 
 class Model(models.Model):
+    # author is the original creator of the model and stays the same across
+    # revisions. uploader is whoever uploaded this particular revision, which
+    # may be the original author or an admin.
     author = models.ForeignKey(User, on_delete=models.CASCADE)
+    uploader = models.ForeignKey(User, null=True, on_delete=models.SET_NULL, related_name='uploaded_models')
     model_id = models.IntegerField()
     revision = models.IntegerField()
     title = models.CharField(max_length=32)

--- a/mainapp/templates/mainapp/model_history.html
+++ b/mainapp/templates/mainapp/model_history.html
@@ -3,7 +3,7 @@
         {% for rev in model.revisions %}
         <a href="{% url 'model' model_id=rev.model_id revision=rev.revision %}" class="list-group-item revision-item {% if rev.revision == model.revision %}active{% endif %}">
             <strong>Revision {{ rev.revision }}</strong>
-            <small>by {{ rev.author.profile.display_name }} on {{ rev.upload_date|date:"c" }}</small>
+            <small>Uploaded by {{ rev.uploader.profile.display_name|default:"a deleted user" }} on {{ rev.upload_date|date:"c" }}</small>
         </a>
         {% endfor %}
     </ul>

--- a/mainapp/templates/mainapp/model_overview.html
+++ b/mainapp/templates/mainapp/model_overview.html
@@ -17,7 +17,14 @@
 <p>Description:</p>
 <p>{{ model.rendered_description|safe }}</p>
 {% endif %}
-<p>Uploaded by <a href="{% url 'user' model.author.profile.uid %}"><span class="label label-default">{{ model.author.profile.display_name }}</span></a> on {{ model.upload_date|date:"c" }}</p>
+<p>Contributed by <a href="{% url 'user' model.author.profile.uid %}"><span class="label label-default">{{ model.author.profile.display_name }}</span></a></p>
+{% if model.revisions|length > 1 %}
+<p>This revision was uploaded
+    {% if model.uploader %}
+    by <a href="{% url 'user' model.uploader.profile.uid %}"><span class="label label-default">{{ model.uploader.profile.display_name }}</span></a>
+    {% endif %}
+    on {{ model.upload_date|date:"c" }}</p>
+{% endif %}
 {% if model.source %}
 <p>From: 
     {% if model.source_is_url %}
@@ -31,8 +38,6 @@
 <a href="{% url 'get_model' model.model_id model.revision %}" class="btn btn-default" role="button">Download</a>
 {% if user.is_authenticated and model.author == user or user.profile.is_admin %}
 <a href="{% url 'edit' model.model_id model.revision %}" class="btn btn-default" role="button">Edit Metadata</a>
-{% endif %}
-{% if user.is_authenticated and model.author == user %}
 <a href="{% url 'revise' model.model_id %}" class="btn btn-default" role="button">Revise</a>
 {% endif %}
 {% if user.is_authenticated and user.profile.is_admin %}

--- a/mainapp/templates/mainapp/modelpanel.html
+++ b/mainapp/templates/mainapp/modelpanel.html
@@ -23,7 +23,7 @@
 			{% if hide_user %}
 			<p>Upload date: {{ model.upload_date|date:"c" }}</p>
 			{% else %}
-			<p>Uploaded by <a href="{% url 'user' uid=model.author.profile.uid %}"><span class="label label-default">{{ model.author.profile.display_name }}</span></a> on {{ model.upload_date|date:"c" }}</p>
+			<p>Contributed by <a href="{% url 'user' uid=model.author.profile.uid %}"><span class="label label-default">{{ model.author.profile.display_name }}</span></a> on {{ model.upload_date|date:"c" }}</p>
 			{% endif %}
 		</div>
 	</div>

--- a/mainapp/tests/test_database.py
+++ b/mainapp/tests/test_database.py
@@ -55,6 +55,7 @@ class DatabaseTests(TestCase):
         self.assertIsNotNone(created_model, "Model creation should not return None")
         self.assertEqual(created_model.title, options["title"])
         self.assertEqual(created_model.author, options["author"])
+        self.assertEqual(created_model.uploader, options["author"])
         self.assertEqual(
             created_model.rendered_description, markdown(options["description"])
         )
@@ -184,8 +185,13 @@ class DatabaseTests(TestCase):
         self.assertEqual(revised_model.revision, 2, "Revision number should increment")
         self.assertEqual(
             revised_model.author,
+            initial_user,
+            "Author should remain the original creator for the new revision",
+        )
+        self.assertEqual(
+            revised_model.uploader,
             revision_author,
-            "Author should be updated for the new revision",
+            "Uploader should be the user who uploaded the new revision",
         )
         self.assertEqual(revised_model.title, initial_model.title)
         self.assertEqual(revised_model.license, initial_model.license)
@@ -193,7 +199,8 @@ class DatabaseTests(TestCase):
         latest_model = Model.objects.get(model_id=initial_model.model_id, latest=True)
         self.assertEqual(latest_model.revision, 2)
         self.assertEqual(latest_model.title, initial_model.title)
-        self.assertEqual(latest_model.author, revision_author)
+        self.assertEqual(latest_model.author, initial_user)
+        self.assertEqual(latest_model.uploader, revision_author)
 
         change_record = Change.objects.get(model=revised_model)
         self.assertEqual(change_record.author, revision_author)

--- a/mainapp/tests/views/test_model.py
+++ b/mainapp/tests/views/test_model.py
@@ -338,6 +338,73 @@ class ReviseModelViewTest(BaseViewTestMixin, TestCase):
         self.assertIsInstance(response.context["form"], UploadFileForm)
         self.assertEqual(response.context["model"].pk, self.model3.pk)
 
+    def test_revise_view_get_admin_non_author(self):
+        self.login_user("admin")
+        response = self.client.get(
+            reverse("revise", args=[self.model3.model_id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "mainapp/revise.html")
+        self.assertEqual(response.context["model"].pk, self.model3.pk)
+
+    def test_revise_view_get_non_author_rejected(self):
+        self.login_user()
+        response = self.client.get(
+            reverse("revise", args=[self.model2.model_id])
+        )
+        self.assertRedirects(
+            response,
+            reverse("model", args=[self.model2.model_id, self.model2.revision]),
+            fetch_redirect_response=False,
+        )
+
+    @patch("mainapp.views.database.upload")
+    @patch("mainapp.forms.validate_glb_file")
+    def test_revise_view_post_admin_non_author(self, mock_validate, mock_db_upload):
+        mock_validate.return_value = []
+        mock_db_upload.return_value = Model(
+            model_id=self.model3.model_id, revision=2, author=self.user
+        )
+        self.login_user("admin")
+
+        dummy_file = SimpleUploadedFile(
+            "test_revision.glb", self.model_file, content_type="model/gltf-binary"
+        )
+
+        response = self.client.post(
+            reverse("revise", args=[self.model3.model_id]),
+            data={"model_file": dummy_file},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        mock_db_upload.assert_called_once()
+        call_args = mock_db_upload.call_args[0]
+        self.assertEqual(int(call_args[1]["model_id"]), self.model3.model_id)
+        self.assertTrue(call_args[1]["revision"])
+        self.assertEqual(call_args[1]["author"], self.admin_user)
+
+    @patch("mainapp.views.database.upload")
+    @patch("mainapp.forms.validate_glb_file")
+    def test_revise_view_post_non_author_rejected(self, mock_validate, mock_db_upload):
+        mock_validate.return_value = []
+        self.login_user()
+
+        dummy_file = SimpleUploadedFile(
+            "test_revision.glb", self.model_file, content_type="model/gltf-binary"
+        )
+
+        response = self.client.post(
+            reverse("revise", args=[self.model2.model_id]),
+            data={"model_file": dummy_file},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("model", args=[self.model2.model_id, self.model2.revision]),
+            fetch_redirect_response=False,
+        )
+        mock_db_upload.assert_not_called()
+
     @patch("mainapp.views.database.upload")
     @patch("mainapp.forms.validate_glb_file")
     def test_revise_view_post_success(self, mock_validate, mock_db_upload):

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -85,7 +85,7 @@ def model(request, model_id, revision=None):
         raise Http404('Model does not exist.')
 
     model.revisions = Model.objects.filter(model_id=model_id) \
-    .select_related('author__profile').order_by('-revision')
+    .select_related('uploader__profile').order_by('-revision')
 
     context = {
         'model': model,
@@ -244,8 +244,8 @@ def revise(request, model_id):
         if not request.user.is_authenticated:
             messages.error(request, 'You must be logged in to use this feature.')
             return redirect(index)
-        elif request.user != m.author:
-            messages.error(request, 'You must be the author of the model to revise it.')
+        elif request.user != m.author and not admin(request):
+            messages.error(request, 'You must be the author of the model or an admin user to revise it.')
             return redirect(model, model_id=m.model_id, revision=m.revision)
         elif form.is_valid():
             model_file = request.FILES['model_file']
@@ -264,8 +264,8 @@ def revise(request, model_id):
     else:
         if not request.user.is_authenticated:
             return redirect(index)
-        elif request.user != m.author:
-            messages.error(request, 'You must be the author of the model to revise it.')
+        elif request.user != m.author and not admin(request):
+            messages.error(request, 'You must be the author of the model or an admin user to revise it.')
             return redirect(model, model_id=m.model_id, revision=m.revision)
 
         form = UploadFileForm()


### PR DESCRIPTION
Closes #62 

This PR introduces a new column `uploader`, and allows model revisions by the admin.

An author is the original creator of the model and stays the same across revisions. While uploader is whoever uploaded this particular revision, which may be the original author or any of the admins.

Verified the expected flow locally as well as with unit tests.